### PR TITLE
Add audio analysis and auto-control features

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,143 @@
+# Captivate — Architecture Overview
+
+**What it is**: Electron + React app for controlling DMX fixtures and WLED addressable LED strips. Uses Ableton Link (node-link) for BPM sync.
+
+---
+
+## Stack
+
+- Electron (main process) + React/Redux (renderer)
+- Redux Toolkit for state, styled-components for UI
+- `node-link` native addon for Ableton Link BPM sync
+- IPC between main and renderer for realtime state
+
+---
+
+## Key State
+
+```
+Redux (CleanReduxState):
+├── dmx.universe[]            — DMX fixtures + channel assignments
+├── dmx.fixtureTypesByID      — Fixture type definitions
+├── dmx.led.ledFixtures[]     — WLedFixture[] (WLED strips)
+├── dmx.led.activeFixture     — Currently selected LED fixture index
+├── control.light             — Light scenes (byId, active)
+├── control.master            — Master brightness
+└── gui.ledEnabled            — Gates WLED tab visibility + broadcast output
+    gui.activePage            — Current UI tab
+
+RealtimeState (90 Hz, sent via IPC):
+├── time: TimeState           — beats, bpm, dt, isPlaying
+├── dmxOut: number[512]       — Live DMX channel values
+├── wledOut: { [mdns]: BaseColors[] } — Live per-LED RGB values per fixture
+└── splitStates[]             — Per-split outputParams (hue, sat, bright, x, y, width, height...)
+```
+
+---
+
+## Engine Loop (main process, 90 Hz)
+
+`src/main/engine/engine.ts` → `getNextRealtimeState()` → computes `splitStates` + `dmxOut` + `wledOut` → sends to renderer via IPC.
+
+`WledManager` (separate 60 Hz loop) reads `realtimeState.wledOut` → calls `WledDevice.broadcast()` per fixture.
+
+Both `calculateDmx` and `calculateWledOut` are gated on `timeState.isPlaying` — Start/Stop controls both DMX and WLED output.
+
+---
+
+## WLED Data Flow
+
+```
+Scene params (hue/sat/bright/x/y/width/height)
+  ↓ (per splitScene, via splitStates in RealtimeState)
+calculateWledOut() — runs in 90 Hz engine loop
+  → getLedFixturesInGroups() — match LED fixtures to scene groups
+  → getLedValues(params, fixture, master) — compute per-LED RGB
+  → stored in realtimeState.wledOut
+
+WledManager.broadcastInterval (60 Hz)
+  → reads realtimeState.wledOut
+  → WledDevice.broadcast(colors) — send UDP DRGB or DDP packet
+```
+
+**Key requirements for WLED to respond to a scene:**
+- `gui.ledEnabled` must be `true` (toggles the LED tab and enables broadcast)
+- `time.isPlaying` must be `true` (Start/Stop button)
+- LED fixture `groups[]` must overlap with the scene's splitScene groups
+
+---
+
+## WLED Fixture Model
+
+```typescript
+interface WLedFixture {
+  mdns: string        // hostname, e.g. "wled-strip1" (no .local suffix)
+  protocol: 'DDP' | 'UDP'
+  led_count: number   // max 490 for UDP; DDP has no practical limit
+  points: Point[]     // waypoints in 0–1 normalized grid space
+  groups: string[]    // must match scene groups for scene to drive it
+  window?: Window2D_t // optional static axis override (advanced)
+}
+```
+
+Points define a polyline path in the 2D grid; `led_count` LEDs are interpolated along it proportionally.
+
+---
+
+## WLED Protocol
+
+**UDP DRGB** (all WLED versions, max 490 LEDs):
+- Header: `[0x02, timeout_seconds]`
+- Payload: `R, G, B, R, G, B, ...` (3 bytes × led_count, values 0–255)
+
+**DDP** (WLED 0.13+, recommended):
+- Header: 10 bytes (flags, sequence, data type, destination, offset, length)
+- Payload: RGB bytes, no LED count limit
+- Use DDP if firmware ≥ 0.13 — the app detects this automatically via Test Connection
+
+The app auto-falls back from DDP → UDP after 10 consecutive failures.
+
+---
+
+## UI Pages
+
+| Page | File | Purpose |
+|------|------|---------|
+| Universe | `src/renderer/pages/Universe.tsx` | DMX fixture setup |
+| Led | `src/renderer/pages/LedPage.tsx` | WLED fixture list + grid placement |
+| Modulation | `src/renderer/pages/Scenes.tsx` | Light scene editor |
+| Mixer | `src/renderer/pages/Mixer.tsx` | DMX output review (512 channel sliders) |
+| WledMixer | `src/renderer/pages/WledMixer.tsx` | LED output review (per-fixture colour strips) |
+| Video | `src/renderer/pages/VisualizerPage.tsx` | Visual scenes |
+
+Menu controlled by `src/renderer/redux/guiSlice.ts` → `Page` union type → `src/renderer/menu/MenuBar.tsx` → `src/renderer/App.tsx` routing.
+
+---
+
+## Key Shared Utilities
+
+| Function | File | Purpose |
+|----------|------|---------|
+| `getLedValues(params, fixture, master)` | `src/shared/ledFixtures.ts` | Compute per-LED BaseColors[] from scene params |
+| `pointsToSegments(points)` | `src/shared/ledFixtures.ts` | Convert fixture waypoints to line segments |
+| `getLedFixturesInGroups()` | `src/shared/dmxUtil.ts` | Filter LED fixtures by scene groups |
+| `getWindowMultiplier()` | `src/shared/dmxUtil.ts` | Moving window brightness multiplier |
+| `getBaseColorsFromHsv()` | `src/shared/baseColors.ts` | HSV → RGB conversion |
+| `calculateDmx()` | `src/main/engine/dmxEngine.ts` | 512-channel DMX output from scene state |
+| `calculateWledOut()` | `src/main/engine/engine.ts` | Per-fixture LED colours from scene state |
+
+---
+
+## WledDevice Connection State Machine
+
+```
+disconnected → discovering → connected
+                                ↓
+                             error → discovering (with backoff)
+```
+
+`isConnected()` requires: `connectionState === 'connected'` AND `lastSeen` (mDNS) < 15s AND `lastHttpSuccess` < 15s.
+
+Both `lastSeen` and `lastHttpSuccess` are refreshed on each successful broadcast, keeping the connection alive during active output.
+
+On initial startup: mDNS response triggers an immediate HTTP check so both timestamps are populated without needing a manual kick-start.

--- a/src/main/engine/engine.ts
+++ b/src/main/engine/engine.ts
@@ -23,11 +23,17 @@ import openVisualizerWindow, {
 import { calculateDmx } from './dmxEngine'
 import { getLedValues } from '../../shared/ledFixtures'
 import { BaseColors } from '../../shared/baseColors'
+import { applyLedEffect } from '../../shared/ledPatterns'
+import { AudioFeatures, AudioModulator } from '../../shared/audioFeatures'
+import { getLatestAudioFeatures } from './ipcHandler'
+import { Params } from '../../shared/params'
 import { handleAutoScene } from '../../shared/autoScene'
-import { setActiveScene } from '../../renderer/redux/controlSlice'
+import { setActiveScene, setLightSceneById } from '../../renderer/redux/controlSlice'
+import { AUTO_SCENE_ID } from '../../renderer/redux/autoControlSlice'
+import { resolveBehavior } from '../../shared/vibeBehavior'
+import { initLightScene, initSplitScene, LightScene_t } from '../../shared/Scenes'
 import TapTempoEngine from './TapTempoEngine'
-import { flatten_fixtures, getFixturesInGroups, getLedFixturesInGroups } from '../../shared/dmxUtil'
-import { LightScene_t } from '../../shared/Scenes'
+import { flatten_fixtures, getFixturesInGroups, getLedFixturesInGroups, getSortedGroups } from '../../shared/dmxUtil'
 import { ThrottleMap } from './midiConnection'
 import { MidiMessage, midiInputID } from '../../shared/midi'
 import { getAllParamKeys } from '../../renderer/redux/dmxSlice'
@@ -53,6 +59,7 @@ let _controlState: CleanReduxState | null = null
 let _realtimeState: RealtimeState = initRealtimeState()
 let _lastFrameTime = 0
 const _tapTempoEngine = new TapTempoEngine()
+let _lastAutoVibe = ''
 function _tapTempo() {
   if (_nodeLink === null) return
   const nodeLink = _nodeLink
@@ -202,6 +209,56 @@ function getNextTimeState(): TimeState {
   }
 }
 
+function generateAutoScene(
+  ipcCallbacks: IPC_Callbacks,
+  controlState: CleanReduxState,
+  vibe: string
+) {
+  const autoControl = controlState.autoControl
+  if (!autoControl.enabled) return
+
+  const dmx = controlState.dmx
+  const allGroups = getSortedGroups(
+    dmx.universe,
+    dmx.fixtureTypes,
+    dmx.fixtureTypesByID,
+    dmx.led.ledFixtures
+  )
+
+  const splitScenes = allGroups
+    .filter((group) => {
+      const role = autoControl.groupRoles[group] ?? 'off'
+      return role !== 'off'
+    })
+    .map((group) => {
+      const role = autoControl.groupRoles[group] ?? 'off'
+      const behavior = resolveBehavior(role as any, vibe as any, autoControl.behaviorMap)
+      const groupDepth = autoControl.perGroupDepth[group] ?? 1
+      const depth = autoControl.globalDepth * groupDepth
+      const splitScene = initSplitScene()
+      splitScene.groups = { [group]: true }
+      splitScene.ledEffect = behavior.ledEffect
+      splitScene.baseParams = {
+        hue: behavior.hueOverride ?? 0,
+        saturation: behavior.saturation,
+        brightness: behavior.brightness * depth,
+      }
+      return splitScene
+    })
+
+  if (splitScenes.length === 0) return
+
+  const autoScene = {
+    ...initLightScene(),
+    name: 'Auto',
+    splitScenes,
+  }
+
+  ipcCallbacks.send_dispatch(
+    setLightSceneById({ id: AUTO_SCENE_ID, scene: autoScene })
+  )
+}
+
 function getNextRealtimeState(
   realtimeState: RealtimeState,
   nextTimeState: TimeState,
@@ -237,14 +294,30 @@ function getNextRealtimeState(
 
   const fixtures = flatten_fixtures(dmx.universe, dmx.fixtureTypesByID)
 
+  const audioFeatures = getLatestAudioFeatures()
+
+  // Auto scene generation — regenerate when vibe changes
+  const currentVibe = audioFeatures.vibe ?? 'neutral'
+  if (currentVibe !== _lastAutoVibe) {
+    _lastAutoVibe = currentVibe
+    generateAutoScene(ipcCallbacks, controlState, currentVibe)
+  }
+
   const splitStates: SplitState[] = scene.splitScenes.map(
     (splitScene, splitIndex) => {
-      const splitOutputParams = getOutputParams(
+      let splitOutputParams = getOutputParams(
         nextTimeState.beats,
         scene,
         splitIndex,
         allParamKeys
       )
+      if (scene.audioModulators && scene.audioModulators.length > 0) {
+        splitOutputParams = applyAudioModulators(
+          splitOutputParams,
+          scene.audioModulators,
+          audioFeatures
+        )
+      }
       let splitSceneFixtures = getFixturesInGroups(fixtures, splitScene.groups)
       let splitSceneFixturesWithinEpicness = splitSceneFixtures.filter(
         (fixture) => fixture.intensity <= (splitOutputParams.intensity ?? 1)
@@ -276,7 +349,27 @@ function getNextRealtimeState(
     dmxOut: calculateDmx(controlState, splitStates, nextTimeState),
     splitStates,
     wledOut: calculateWledOut(controlState, splitStates, scene, nextTimeState),
+    audioFeatures: realtimeState.audioFeatures,
   }
+}
+
+// Exponential moving average smoothing state (per modulator, per call)
+// We use a simple approximation here since audio features are updated ~20 Hz
+function applyAudioModulators(
+  params: Params,
+  modulators: AudioModulator[],
+  features: AudioFeatures
+): Params {
+  if (!features.enabled || modulators.length === 0) return params
+  const result: Params = { ...params }
+  for (const mod of modulators) {
+    const raw = features[mod.source] as number
+    const mapped = mod.min + raw * (mod.max - mod.min)
+    const existing = (result[mod.target] as number | undefined) ?? 0
+    // Smooth: blend toward new value (smoothing=0 → instant, smoothing=1 → frozen)
+    result[mod.target] = existing * mod.smoothing + mapped * (1 - mod.smoothing)
+  }
+  return result
 }
 
 function maxBlendColors(a: BaseColors, b: BaseColors): BaseColors {
@@ -308,7 +401,10 @@ function calculateWledOut(
     const matchingFixtures = getLedFixturesInGroups(ledFixtures, splitScene.groups)
 
     for (const fixture of matchingFixtures) {
-      const colors = getLedValues(splitState.outputParams, fixture, master)
+      let colors = getLedValues(splitState.outputParams, fixture, master)
+      if (splitScene.ledEffect && splitScene.ledEffect.type !== 'none') {
+        colors = applyLedEffect(colors, splitScene.ledEffect, timeState, splitState.outputParams.hue ?? 0)
+      }
 
       if (!ledOutputs[fixture.mdns]) {
         ledOutputs[fixture.mdns] = indexArray(fixture.led_count).map(() => ({

--- a/src/main/engine/ipcHandler.ts
+++ b/src/main/engine/ipcHandler.ts
@@ -17,6 +17,13 @@ import { VisualizerResource } from '../../visualizer/threejs/VisualizerManager'
 import { VisualizerContainer } from './createVisualizerWindow'
 import { DmxConnectionInfo, WledConnectionInfo } from 'shared/connection'
 import { getWledManager } from './engine'
+import { AudioFeatures, initAudioFeatures } from '../../shared/audioFeatures'
+
+let _latestAudioFeatures: AudioFeatures = initAudioFeatures()
+
+export function getLatestAudioFeatures(): AudioFeatures {
+  return _latestAudioFeatures
+}
 
 interface Config {
   renderer: WebContents
@@ -41,6 +48,10 @@ export function ipcSetup(config: Config) {
 
   ipcMain.on(ipcChannels.open_visualizer, (_e) => {
     _config.on_open_visualizer()
+  })
+
+  ipcMain.on(ipcChannels.audio_features, (_e, features: AudioFeatures) => {
+    _latestAudioFeatures = features
   })
 
   return {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld('electron', {
         'new_control_state',
         'user_command',
         'open_visualizer',
+        'audio_features',
       ]
       if (validChannels.includes(channel)) {
         ipcRenderer.send(channel, ...args)
@@ -25,6 +26,7 @@ contextBridge.exposeInMainWorld('electron', {
         'new_midi_message',
         'dmx_connection_update',
         'midi_connection_update',
+        'wled_connection_update',
         'dispatch',
         'new_control_state',
         'new_time_state',

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,8 @@ import Universe from './pages/Universe'
 import Share from './pages/Share'
 import Mixer from './pages/Mixer'
 import WledMixer from './pages/WledMixer'
+import AudioPage from './pages/AudioPage'
+import AutoControlPage from './pages/AutoControlPage'
 import MenuBar from './menu/MenuBar'
 import { useTypedSelector } from './redux/store'
 import FullscreenOverlay from './overlays/FullscreenOverlay'
@@ -24,6 +26,8 @@ export default function App() {
     if (activePage == 'Mixer') return <Mixer />
     if (activePage == 'Led') return <LedPage />
     if (activePage == 'WledMixer') return <WledMixer />
+    if (activePage == 'Audio') return <AudioPage />
+    if (activePage == 'AutoControl') return <AutoControlPage />
     console.error(`Bad activePage value: ${activePage}`)
     return null
   }

--- a/src/renderer/hooks/useAudioAnalyzer.ts
+++ b/src/renderer/hooks/useAudioAnalyzer.ts
@@ -1,0 +1,290 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  AudioFeatures,
+  VibeAxes,
+  VibeType,
+  classifyVibe,
+  initAudioFeatures,
+  initVibeAxes,
+} from '../../shared/audioFeatures'
+import { useRealtimeDispatch } from '../redux/realtimeStore'
+import { send_audio_features } from '../ipcHandler'
+
+const FFT_SIZE = 2048
+const ENERGY_HISTORY_FRAMES = 120  // ~2 s at 60 fps
+const ONSET_HISTORY_FRAMES = 180   // ~3 s at 60 fps for BPM autocorr
+const BPM_UPDATE_EVERY = 60        // frames between BPM recalculations
+const VIBE_UPDATE_EVERY = 30       // frames between vibe reclassification (~0.5s)
+const SLOW_EMA = 0.97              // τ ≈ 2s at 60fps for vibe axis smoothing
+const FAST_EMA = 0.85              // τ ≈ 0.3s at 60fps for pulse axis
+
+function bandMean(data: Uint8Array, lo: number, hi: number): number {
+  const count = hi - lo + 1
+  if (count <= 0) return 0
+  let sum = 0
+  for (let k = lo; k <= hi; k++) sum += data[k]
+  return sum / (count * 255)
+}
+
+function autocorrBpm(onsets: number[], sampleRate: number): number {
+  const n = onsets.length
+  if (n < 60) return 0
+  let bestBpm = 0
+  let bestScore = -Infinity
+  for (let bpm = 50; bpm <= 200; bpm += 2) {
+    const lagFrames = Math.round((sampleRate * 60) / bpm)
+    if (lagFrames >= n) continue
+    let score = 0
+    for (let i = lagFrames; i < n; i++) score += onsets[i] * onsets[i - lagFrames]
+    score /= n - lagFrames
+    if (score > bestScore) { bestScore = score; bestBpm = bpm }
+  }
+  return bestScore > 0.0005 ? bestBpm : 0
+}
+
+export interface AudioAnalyzerControls {
+  devices: MediaDeviceInfo[]
+  deviceId: string | null
+  enabled: boolean
+  setDeviceId: (id: string | null) => void
+  setEnabled: (enabled: boolean) => void
+}
+
+export function useAudioAnalyzer(): AudioAnalyzerControls {
+  const dispatch = useRealtimeDispatch()
+  const [devices, setDevices] = useState<MediaDeviceInfo[]>([])
+  const [deviceId, setDeviceId] = useState<string | null>(null)
+  const [enabled, setEnabled] = useState(false)
+
+  const contextRef = useRef<AudioContext | null>(null)
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const rafRef = useRef<number>(0)
+  const prevDataRef = useRef<Uint8Array | null>(null)
+  const fluxSmoothedRef = useRef(0)
+  const energyHistoryRef = useRef<number[]>([])
+  const onsetHistoryRef = useRef<number[]>([])
+  const frameCountRef = useRef(0)
+  const bpmRef = useRef(0)
+
+  // Vibe axis state (slow-smoothed for stable classification)
+  const vibeAxesSmoothedRef = useRef<VibeAxes>(initVibeAxes())
+  // Fast-smoothed pulse (onset EMA for vibe axis, separate from onset display)
+  const pulseSmoothedRef = useRef(0)
+  // Momentum: two energy averages at different time horizons
+  const energyFastRef = useRef(0)   // ~0.5s EMA
+  const energySlowRef = useRef(0)   // ~3s EMA
+  const vibeRef = useRef<VibeType>('neutral')
+
+  // Enumerate audio input devices
+  useEffect(() => {
+    navigator.mediaDevices
+      .enumerateDevices()
+      .then((list) => setDevices(list.filter((d) => d.kind === 'audioinput')))
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) {
+      cleanup()
+      dispatch({ type: 'updateAudioFeatures', payload: initAudioFeatures() })
+      return
+    }
+
+    let cancelled = false
+
+    async function start() {
+      try {
+        const constraints: MediaStreamConstraints = {
+          audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+        }
+        const stream = await navigator.mediaDevices.getUserMedia(constraints)
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop())
+          return
+        }
+
+        streamRef.current = stream
+        const ctx = new AudioContext()
+        contextRef.current = ctx
+        // Resume immediately — Chromium suspends AudioContext if not created
+        // directly inside a user-gesture handler (autoplay policy).
+        await ctx.resume()
+        const analyser = ctx.createAnalyser()
+        analyser.fftSize = FFT_SIZE
+        analyser.smoothingTimeConstant = 0.8
+        analyserRef.current = analyser
+
+        const source = ctx.createMediaStreamSource(stream)
+        source.connect(analyser)
+        startLoop(analyser, ctx.sampleRate)
+      } catch (err) {
+        console.error('[AudioAnalyzer] getUserMedia error:', err)
+      }
+    }
+
+    start()
+    return () => {
+      cancelled = true
+      cleanup()
+    }
+  }, [enabled, deviceId])
+
+  function cleanup() {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current)
+    streamRef.current?.getTracks().forEach((t) => t.stop())
+    contextRef.current?.close().catch(() => {})
+    streamRef.current = null
+    contextRef.current = null
+    analyserRef.current = null
+    prevDataRef.current = null
+    fluxSmoothedRef.current = 0
+    energyHistoryRef.current = []
+    onsetHistoryRef.current = []
+    frameCountRef.current = 0
+    bpmRef.current = 0
+    vibeAxesSmoothedRef.current = initVibeAxes()
+    pulseSmoothedRef.current = 0
+    energyFastRef.current = 0
+    energySlowRef.current = 0
+    vibeRef.current = 'neutral'
+  }
+
+  function startLoop(analyser: AnalyserNode, sampleRate: number) {
+    const binCount = analyser.frequencyBinCount // FFT_SIZE / 2
+    const data = new Uint8Array(binCount)
+    const binHz = sampleRate / FFT_SIZE
+
+    // Precompute band bin ranges
+    const bassLo = Math.max(0, Math.floor(20 / binHz))
+    const bassHi = Math.min(binCount - 1, Math.floor(250 / binHz))
+    const midsLo = Math.min(binCount - 1, Math.floor(250 / binHz) + 1)
+    const midsHi = Math.min(binCount - 1, Math.floor(4000 / binHz))
+    const trebleLo = Math.min(binCount - 1, Math.floor(4000 / binHz) + 1)
+    const trebleHi = Math.min(binCount - 1, Math.floor(20000 / binHz))
+
+    function loop() {
+      // Re-resume if Chromium suspended the context (e.g. after window blur)
+      if (contextRef.current && contextRef.current.state === 'suspended') {
+        contextRef.current.resume()
+      }
+      analyser.getByteFrequencyData(data)
+      frameCountRef.current++
+
+      // --- Energy (RMS proxy) ---
+      let energySum = 0
+      for (let k = 0; k < binCount; k++) {
+        const v = data[k] / 255
+        energySum += v * v
+      }
+      const energy = Math.sqrt(energySum / binCount)
+
+      // --- Frequency bands ---
+      const bass = bandMean(data, bassLo, bassHi)
+      const mids = bandMean(data, midsLo, midsHi)
+      const treble = bandMean(data, trebleLo, trebleHi)
+
+      // --- Spectral centroid (normalized 0–1) ---
+      let weightedSum = 0
+      let magnitudeSum = 0
+      for (let k = 0; k < binCount; k++) {
+        weightedSum += k * data[k]
+        magnitudeSum += data[k]
+      }
+      const centroid = magnitudeSum > 0 ? weightedSum / (magnitudeSum * binCount) : 0
+
+      // --- Spectral flux (half-wave rectified) ---
+      let fluxSum = 0
+      if (prevDataRef.current) {
+        for (let k = 0; k < binCount; k++) {
+          const diff = data[k] - prevDataRef.current[k]
+          if (diff > 0) fluxSum += diff
+        }
+      }
+      const flux = fluxSum / (binCount * 255)
+      if (!prevDataRef.current) prevDataRef.current = new Uint8Array(binCount)
+      prevDataRef.current.set(data)
+
+      // --- Onset (adaptive flux threshold) ---
+      fluxSmoothedRef.current = 0.9 * fluxSmoothedRef.current + 0.1 * flux
+      const onsetRaw = Math.max(flux - fluxSmoothedRef.current * 1.5, 0) * 10
+      const onset = Math.min(onsetRaw, 1)
+
+      // --- Energy history for drop detection ---
+      const energyHistory = energyHistoryRef.current
+      energyHistory.push(energy)
+      if (energyHistory.length > ENERGY_HISTORY_FRAMES) energyHistory.shift()
+      let maxEnergy = 0
+      for (const e of energyHistory) if (e > maxEnergy) maxEnergy = e
+      const drop = energyHistory.length >= 60 && energy < maxEnergy * 0.5 && maxEnergy > 0.1
+
+      // --- Onset history for BPM autocorrelation ---
+      const onsetHistory = onsetHistoryRef.current
+      onsetHistory.push(onset)
+      if (onsetHistory.length > ONSET_HISTORY_FRAMES) onsetHistory.shift()
+      if (frameCountRef.current % BPM_UPDATE_EVERY === 0) {
+        bpmRef.current = autocorrBpm(onsetHistory, 60)
+      }
+
+      // ── Vibe Axes Computation ──────────────────────────────────────────────
+
+      // heat: bass-heavy = warm (1), treble-heavy/bright = cool (0)
+      const heatRaw = Math.min(1, bass * 0.6 + (1 - centroid) * 0.4)
+
+      // pulse: fast EMA of onset → percussiveness
+      pulseSmoothedRef.current = FAST_EMA * pulseSmoothedRef.current + (1 - FAST_EMA) * onset
+      const pulseRaw = pulseSmoothedRef.current
+
+      // groove: mid-to-energy ratio → syncopated mid-range fullness
+      const grooveRaw = Math.min(1, mids / (energy + 0.01))
+
+      // momentum: fast vs slow energy trend → rising = building
+      energyFastRef.current = 0.90 * energyFastRef.current + 0.10 * energy  // ~0.7s
+      energySlowRef.current = 0.98 * energySlowRef.current + 0.02 * energy  // ~3s
+      const slope = energyFastRef.current - energySlowRef.current           // positive = rising
+      const momentumRaw = Math.min(1, Math.max(0, slope * 5 + 0.5))         // center at 0.5
+
+      // Slow-smooth all axes for stable vibe classification
+      const ax = vibeAxesSmoothedRef.current
+      ax.heat = SLOW_EMA * ax.heat + (1 - SLOW_EMA) * heatRaw
+      ax.energy = SLOW_EMA * ax.energy + (1 - SLOW_EMA) * energy
+      ax.pulse = SLOW_EMA * ax.pulse + (1 - SLOW_EMA) * pulseRaw
+      ax.groove = SLOW_EMA * ax.groove + (1 - SLOW_EMA) * grooveRaw
+      ax.momentum = SLOW_EMA * ax.momentum + (1 - SLOW_EMA) * momentumRaw
+
+      // Reclassify vibe periodically on the smoothed axes
+      if (frameCountRef.current % VIBE_UPDATE_EVERY === 0) {
+        vibeRef.current = classifyVibe(ax)
+      }
+
+      const vibeAxes: VibeAxes = { ...ax }
+
+      // ── Assemble AudioFeatures ─────────────────────────────────────────────
+      const features: AudioFeatures = {
+        enabled: true,
+        energy,
+        bass,
+        mids,
+        treble,
+        centroid,
+        flux,
+        onset,
+        drop,
+        bpm: bpmRef.current,
+        vibeAxes,
+        vibe: vibeRef.current,
+      }
+
+      dispatch({ type: 'updateAudioFeatures', payload: features })
+      // Send to main process every 3 frames (~20 Hz) for audio modulation
+      if (frameCountRef.current % 3 === 0) {
+        send_audio_features(features)
+      }
+      rafRef.current = requestAnimationFrame(loop)
+    }
+
+    rafRef.current = requestAnimationFrame(loop)
+  }
+
+  return { devices, deviceId, enabled, setDeviceId, setEnabled }
+}

--- a/src/renderer/ipcHandler.ts
+++ b/src/renderer/ipcHandler.ts
@@ -4,6 +4,7 @@ import { RealtimeState } from './redux/realtimeStore'
 import * as midiConnection from '../main/engine/midiConnection'
 import { PayloadAction } from '@reduxjs/toolkit'
 import { DmxConnectionInfo, WledConnectionInfo } from 'shared/connection'
+import { AudioFeatures } from 'shared/audioFeatures'
 
 interface Config {
   on_dmx_connection_update: (payload: DmxConnectionInfo) => void
@@ -60,6 +61,9 @@ export function send_user_command(command: UserCommand) {
 }
 export function send_open_visualizer() {
   ipcRenderer.send(ipc_channels.open_visualizer)
+}
+export function send_audio_features(features: AudioFeatures) {
+  ipcRenderer.send(ipc_channels.audio_features, features)
 }
 export async function getLocalFilepaths(
   title: string,

--- a/src/renderer/menu/MenuBar.tsx
+++ b/src/renderer/menu/MenuBar.tsx
@@ -7,6 +7,8 @@ import WbIncandescentIcon from '@mui/icons-material/WbIncandescent'
 import LedOutputIcon from '@mui/icons-material/LinearScale'
 import VisualsIcon from '../images/Thick.png'
 import MixerIcon from '@mui/icons-material/BarChart'
+import AudioIcon from '@mui/icons-material/GraphicEq'
+import AutoControlIcon from '@mui/icons-material/Tune'
 import { useTypedSelector } from '../redux/store'
 import { useDispatch } from 'react-redux'
 import { setActivePage, Page } from '../redux/guiSlice'
@@ -19,6 +21,7 @@ export default function MenuBar() {
   const dispatch = useDispatch()
   const ledEnabled = useTypedSelector((state) => state.gui.ledEnabled)
   const videoEnabled = useTypedSelector((state) => state.gui.videoEnabled)
+  const audioEnabled = useTypedSelector((state) => state.gui.audioEnabled)
 
   const setPage = (newPage: Page) => {
     return () => {
@@ -81,6 +84,14 @@ export default function MenuBar() {
       <MenuItem page="Mixer" tooltipText="DMX Mixer">
         <MixerIcon fontSize="inherit" />
       </MenuItem>
+      <MenuItem page="Audio" tooltipText="Audio Analysis">
+        <AudioIcon fontSize="inherit" />
+      </MenuItem>
+      {audioEnabled && (
+        <MenuItem page="AutoControl" tooltipText="Auto Control">
+          <AutoControlIcon fontSize="inherit" />
+        </MenuItem>
+      )}
       <Spacer />
       <MasterSlider />
       <div style={{ height: '0.5rem' }} />

--- a/src/renderer/pages/AudioPage.tsx
+++ b/src/renderer/pages/AudioPage.tsx
@@ -1,0 +1,328 @@
+import styled from 'styled-components'
+import StatusBar from '../menu/StatusBar'
+import { useAudioAnalyzer } from '../hooks/useAudioAnalyzer'
+import { useRealtimeSelector } from '../redux/realtimeStore'
+import { useDispatch } from 'react-redux'
+import { toggleAudioEnabled } from '../redux/guiSlice'
+import { useTypedSelector } from '../redux/store'
+import { VIBE_HUE } from '../../shared/audioFeatures'
+
+export default function AudioPage() {
+  const dispatch = useDispatch()
+  const audioEnabled = useTypedSelector((s) => s.gui.audioEnabled)
+  const { devices, deviceId, enabled, setDeviceId, setEnabled } =
+    useAudioAnalyzer()
+  const features = useRealtimeSelector((s) => s.audioFeatures)
+
+  function handleToggleEnabled() {
+    setEnabled(!enabled)
+    // Keep guiState in sync so AutoControl tab visibility works
+    if (!enabled !== audioEnabled) {
+      dispatch(toggleAudioEnabled())
+    }
+  }
+
+  return (
+    <Root>
+      <StatusBar />
+      <Content>
+        <Header>
+          <HeaderTitle>Audio Analysis</HeaderTitle>
+        </Header>
+
+        <Section>
+          <SectionLabel>Input Device</SectionLabel>
+          <Row>
+            <DeviceSelect
+              value={deviceId ?? ''}
+              onChange={(e) => setDeviceId(e.target.value || null)}
+            >
+              <option value="">Default input</option>
+              {devices.map((d) => (
+                <option key={d.deviceId} value={d.deviceId}>
+                  {d.label || `Input ${d.deviceId.slice(0, 8)}`}
+                </option>
+              ))}
+            </DeviceSelect>
+            <EnableButton $active={enabled} onClick={handleToggleEnabled}>
+              {enabled ? 'Enabled' : 'Enable'}
+            </EnableButton>
+          </Row>
+        </Section>
+
+        {enabled && (
+          <>
+            <Section>
+              <SectionLabel>Vibe</SectionLabel>
+              <VibeChip $hue={VIBE_HUE[features.vibe]}>
+                {features.vibe.toUpperCase()}
+              </VibeChip>
+              <AxisGrid>
+                <AxisRow label="Heat" value={features.vibeAxes.heat} />
+                <AxisRow label="Energy" value={features.vibeAxes.energy} />
+                <AxisRow label="Pulse" value={features.vibeAxes.pulse} />
+                <AxisRow label="Groove" value={features.vibeAxes.groove} />
+                <AxisRow label="Momentum" value={features.vibeAxes.momentum} />
+              </AxisGrid>
+            </Section>
+
+            <Section>
+              <SectionLabel>Features</SectionLabel>
+              <MetersGrid>
+                <MeterRow label="Energy" value={features.energy} />
+                <MeterRow label="Bass" value={features.bass} color="#e57373" />
+                <MeterRow label="Mids" value={features.mids} color="#81c784" />
+                <MeterRow
+                  label="Treble"
+                  value={features.treble}
+                  color="#64b5f6"
+                />
+                <MeterRow
+                  label="Onset"
+                  value={features.onset}
+                  color="#ffb74d"
+                />
+                <MeterRow
+                  label="Flux"
+                  value={features.flux}
+                  color="#ce93d8"
+                />
+                <MeterRow
+                  label="Centroid"
+                  value={features.centroid}
+                  color="#80deea"
+                />
+              </MetersGrid>
+            </Section>
+
+            <Section>
+              <SectionLabel>Events</SectionLabel>
+              <EventRow>
+                <EventPill $active={features.onset > 0.3} color="#ffb74d">
+                  Onset
+                </EventPill>
+                <EventPill $active={features.drop} color="#ef9a9a">
+                  Drop
+                </EventPill>
+                {features.bpm > 0 && (
+                  <BpmDisplay>{Math.round(features.bpm)} BPM</BpmDisplay>
+                )}
+              </EventRow>
+            </Section>
+          </>
+        )}
+
+        {!enabled && (
+          <Hint>
+            Enable audio input to start extracting real-time features for
+            reactive lighting and auto-control.
+          </Hint>
+        )}
+      </Content>
+    </Root>
+  )
+}
+
+function MeterRow({
+  label,
+  value,
+  color = '#ffffff',
+}: {
+  label: string
+  value: number
+  color?: string
+}) {
+  const pct = Math.round(value * 100)
+  return (
+    <MeterRowRoot>
+      <MeterLabel>{label}</MeterLabel>
+      <MeterTrack>
+        <MeterFill style={{ width: `${pct}%`, backgroundColor: color }} />
+      </MeterTrack>
+      <MeterValue>{pct}%</MeterValue>
+    </MeterRowRoot>
+  )
+}
+
+function AxisRow({ label, value }: { label: string; value: number }) {
+  const pct = Math.round(value * 100)
+  return (
+    <MeterRowRoot>
+      <AxisLabel>{label}</AxisLabel>
+      <MeterTrack>
+        <AxisFill style={{ width: `${pct}%` }} />
+      </MeterTrack>
+      <MeterValue>{pct}%</MeterValue>
+    </MeterRowRoot>
+  )
+}
+
+const Root = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`
+
+const Content = styled.div`
+  flex: 1 1 0;
+  overflow: auto;
+  padding: 0 1rem 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+`
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 1rem;
+`
+
+const HeaderTitle = styled.div`
+  font-size: 1.3rem;
+`
+
+const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`
+
+const SectionLabel = styled.div`
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`
+
+const DeviceSelect = styled.select`
+  flex: 1;
+  background-color: ${(p) => p.theme.colors.bg.darker};
+  color: ${(p) => p.theme.colors.text.primary};
+  border: 1px solid ${(p) => p.theme.colors.divider};
+  border-radius: 4px;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.9rem;
+`
+
+const EnableButton = styled.button<{ $active: boolean }>`
+  padding: 0.35rem 1rem;
+  border-radius: 4px;
+  border: 1px solid ${(p) => (p.$active ? '#4caf50' : p.theme.colors.divider)};
+  background-color: ${(p) => (p.$active ? '#1b5e20' : 'transparent')};
+  color: ${(p) => (p.$active ? '#a5d6a7' : p.theme.colors.text.primary)};
+  cursor: pointer;
+  font-size: 0.9rem;
+  white-space: nowrap;
+`
+
+const MetersGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+`
+
+const MeterRowRoot = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+`
+
+const MeterLabel = styled.div`
+  width: 4.5rem;
+  font-size: 0.85rem;
+  text-align: right;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const MeterTrack = styled.div`
+  flex: 1;
+  height: 0.75rem;
+  background-color: ${(p) => p.theme.colors.bg.darker};
+  border-radius: 2px;
+  overflow: hidden;
+`
+
+const MeterFill = styled.div`
+  height: 100%;
+  border-radius: 2px;
+  transition: width 50ms linear;
+`
+
+const MeterValue = styled.div`
+  width: 2.8rem;
+  font-size: 0.8rem;
+  color: ${(p) => p.theme.colors.text.secondary};
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+`
+
+const EventRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`
+
+const EventPill = styled.div<{ $active: boolean; color: string }>`
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  border: 1px solid ${(p) => (p.$active ? p.color : p.theme.colors.divider)};
+  color: ${(p) => (p.$active ? p.color : p.theme.colors.text.secondary)};
+  background-color: ${(p) => (p.$active ? `${p.color}22` : 'transparent')};
+  transition: all 80ms ease;
+`
+
+const BpmDisplay = styled.div`
+  font-size: 1rem;
+  font-weight: 600;
+  color: ${(p) => p.theme.colors.text.primary};
+  margin-left: auto;
+`
+
+const Hint = styled.div`
+  color: ${(p) => p.theme.colors.text.secondary};
+  font-size: 0.9rem;
+  max-width: 30rem;
+  line-height: 1.5;
+`
+
+const VibeChip = styled.div<{ $hue: number }>`
+  display: inline-block;
+  padding: 0.35rem 1.1rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  border: 1.5px solid ${(p) => `hsl(${Math.round(p.$hue * 360)}, 80%, 55%)`};
+  color: ${(p) => `hsl(${Math.round(p.$hue * 360)}, 80%, 70%)`};
+  background-color: ${(p) => `hsl(${Math.round(p.$hue * 360)}, 60%, 15%)`};
+  transition: all 400ms ease;
+`
+
+const AxisGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.25rem;
+`
+
+const AxisLabel = styled.div`
+  width: 4.5rem;
+  font-size: 0.8rem;
+  text-align: right;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const AxisFill = styled.div`
+  height: 100%;
+  border-radius: 2px;
+  background-color: #9fa8da;
+  transition: width 200ms linear;
+`

--- a/src/renderer/pages/AutoControlPage.tsx
+++ b/src/renderer/pages/AutoControlPage.tsx
@@ -1,0 +1,413 @@
+import styled from 'styled-components'
+import StatusBar from '../menu/StatusBar'
+import { useRealtimeSelector } from '../redux/realtimeStore'
+import { useDmxSelector, useTypedSelector } from '../redux/store'
+import { useDispatch } from 'react-redux'
+import {
+  setAutoEnabled,
+  setGroupRole,
+  setGlobalDepth,
+  setPerGroupDepth,
+  AUTO_SCENE_ID,
+} from '../redux/autoControlSlice'
+import { GroupRole, GROUP_ROLES, GROUP_ROLE_LABELS, GROUP_ROLE_DESCRIPTIONS } from '../../shared/groupRoles'
+import { VIBE_HUE, VIBE_TYPES, VibeType } from '../../shared/audioFeatures'
+import { getSortedGroups } from '../../shared/dmxUtil'
+import Slider from '@mui/material/Slider'
+import Select from '@mui/material/Select'
+import MenuItem from '@mui/material/MenuItem'
+import Switch from '@mui/material/Switch'
+
+export default function AutoControlPage() {
+  const dispatch = useDispatch()
+  const features = useRealtimeSelector((s) => s.audioFeatures)
+  const autoControl = useTypedSelector((s) => s.autoControl)
+  const dmx = useDmxSelector((dmx) => dmx)
+  const autoSceneExists = useTypedSelector(
+    (s) => AUTO_SCENE_ID in s.control.present.light.byId
+  )
+
+  const allGroups = getSortedGroups(
+    dmx.universe,
+    dmx.fixtureTypes,
+    dmx.fixtureTypesByID,
+    dmx.led.ledFixtures
+  )
+
+  const activeGroups = allGroups.filter(
+    (g) => (autoControl.groupRoles[g] ?? 'off') !== 'off'
+  )
+
+  return (
+    <Root>
+      <StatusBar />
+      <Content>
+        <Header>
+          <HeaderTitle>Auto Control</HeaderTitle>
+          <EnableRow>
+            <Switch
+              size="small"
+              checked={autoControl.enabled}
+              onChange={(e) => dispatch(setAutoEnabled(e.target.checked))}
+            />
+            <EnableLabel>{autoControl.enabled ? 'Enabled' : 'Disabled'}</EnableLabel>
+          </EnableRow>
+        </Header>
+
+        {!features.enabled && (
+          <Notice>Enable audio on the Audio tab to activate auto-control.</Notice>
+        )}
+
+        {/* ── Panel 3: Live Status ───────────────────────────────────── */}
+        {features.enabled && (
+          <Section>
+            <SectionLabel>Live Status</SectionLabel>
+            <StatusRow>
+              <VibeChip $hue={VIBE_HUE[features.vibe]}>
+                {features.vibe.toUpperCase()}
+              </VibeChip>
+              <AxisMiniGrid>
+                {(['heat', 'energy', 'pulse', 'groove', 'momentum'] as const).map((ax) => (
+                  <AxisMiniRow key={ax}>
+                    <AxisMiniLabel>{ax}</AxisMiniLabel>
+                    <AxisMiniTrack>
+                      <AxisMiniFill style={{ width: `${Math.round(features.vibeAxes[ax] * 100)}%` }} />
+                    </AxisMiniTrack>
+                  </AxisMiniRow>
+                ))}
+              </AxisMiniGrid>
+            </StatusRow>
+            {autoControl.enabled && autoSceneExists && (
+              <AutoSceneNote>
+                Auto scene is active — select &quot;Auto&quot; in the Scenes list to use it.
+              </AutoSceneNote>
+            )}
+          </Section>
+        )}
+
+        {/* ── Panel 1: Group Roles ───────────────────────────────────── */}
+        <Section>
+          <SectionLabel>Group Roles</SectionLabel>
+          {allGroups.length === 0 && (
+            <EmptyMessage>No fixture groups found. Define groups in the DMX tab.</EmptyMessage>
+          )}
+          <GroupTable>
+            {allGroups.map((group) => {
+              const role = autoControl.groupRoles[group] ?? 'off'
+              const depth = autoControl.perGroupDepth[group] ?? 1
+              return (
+                <GroupRow key={group}>
+                  <GroupName>{group}</GroupName>
+                  <Select
+                    size="small"
+                    value={role}
+                    onChange={(e) =>
+                      dispatch(setGroupRole({ group, role: e.target.value as GroupRole }))
+                    }
+                    sx={{ fontSize: '0.8rem', minWidth: '8rem' }}
+                    title={GROUP_ROLE_DESCRIPTIONS[role]}
+                  >
+                    {GROUP_ROLES.map((r) => (
+                      <MenuItem key={r} value={r} sx={{ fontSize: '0.8rem' }}>
+                        {GROUP_ROLE_LABELS[r]}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  <DepthSliderWrap>
+                    <DepthLabel>Depth {Math.round(depth * 100)}%</DepthLabel>
+                    <Slider
+                      size="small"
+                      value={depth}
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      disabled={role === 'off'}
+                      onChange={(_, v) =>
+                        dispatch(setPerGroupDepth({ group, depth: v as number }))
+                      }
+                    />
+                  </DepthSliderWrap>
+                </GroupRow>
+              )
+            })}
+          </GroupTable>
+        </Section>
+
+        {/* ── Global depth ──────────────────────────────────────────── */}
+        <Section>
+          <SectionLabel>Global Depth</SectionLabel>
+          <GlobalDepthRow>
+            <Slider
+              size="small"
+              value={autoControl.globalDepth}
+              min={0}
+              max={1}
+              step={0.01}
+              onChange={(_, v) => dispatch(setGlobalDepth(v as number))}
+            />
+            <GlobalDepthVal>{Math.round(autoControl.globalDepth * 100)}%</GlobalDepthVal>
+          </GlobalDepthRow>
+        </Section>
+
+        {/* ── Panel 2: Vibe Mapping summary ────────────────────────── */}
+        {activeGroups.length > 0 && (
+          <Section>
+            <SectionLabel>Vibe → Behavior Mapping</SectionLabel>
+            <MapGrid>
+              <MapHeaderRow>
+                <MapCell $header />
+                {activeGroups.map((g) => (
+                  <MapCell key={g} $header>
+                    {g}
+                  </MapCell>
+                ))}
+              </MapHeaderRow>
+              {VIBE_TYPES.map((vibe) => (
+                <MapRow key={vibe} $vibe={vibe}>
+                  <MapVibeLabel $hue={VIBE_HUE[vibe]}>{vibe}</MapVibeLabel>
+                  {activeGroups.map((group) => {
+                    const role = autoControl.groupRoles[group] ?? 'off'
+                    const entry = autoControl.behaviorMap[role]
+                    const effectType = (
+                      entry?.vibeOverrides[vibe]?.ledEffect?.type ??
+                      entry?.default.ledEffect.type ??
+                      'none'
+                    )
+                    return (
+                      <MapCell key={group} title={`${role}: ${effectType}`}>
+                        <EffectBadge>{effectType}</EffectBadge>
+                      </MapCell>
+                    )
+                  })}
+                </MapRow>
+              ))}
+            </MapGrid>
+          </Section>
+        )}
+      </Content>
+    </Root>
+  )
+}
+
+// ── Styled Components ────────────────────────────────────────────────────────
+
+const Root = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`
+
+const Content = styled.div`
+  flex: 1 1 0;
+  overflow: auto;
+  padding: 0 1rem 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+`
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+`
+
+const HeaderTitle = styled.div`
+  font-size: 1.3rem;
+  flex: 1;
+`
+
+const EnableRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+`
+
+const EnableLabel = styled.div`
+  font-size: 0.85rem;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const Notice = styled.div`
+  color: ${(p) => p.theme.colors.text.secondary};
+  font-size: 0.85rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid ${(p) => p.theme.colors.divider};
+  border-radius: 4px;
+`
+
+const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`
+
+const SectionLabel = styled.div`
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const StatusRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+`
+
+const VibeChip = styled.div<{ $hue: number }>`
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+  border: 1.5px solid ${(p) => `hsl(${Math.round(p.$hue * 360)}, 80%, 55%)`};
+  color: ${(p) => `hsl(${Math.round(p.$hue * 360)}, 80%, 70%)`};
+  background-color: ${(p) => `hsl(${Math.round(p.$hue * 360)}, 60%, 15%)`};
+  transition: all 400ms ease;
+`
+
+const AxisMiniGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  flex: 1;
+`
+
+const AxisMiniRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+`
+
+const AxisMiniLabel = styled.div`
+  width: 4rem;
+  font-size: 0.72rem;
+  color: ${(p) => p.theme.colors.text.secondary};
+  text-align: right;
+`
+
+const AxisMiniTrack = styled.div`
+  flex: 1;
+  height: 0.5rem;
+  background-color: ${(p) => p.theme.colors.bg.darker};
+  border-radius: 2px;
+  overflow: hidden;
+`
+
+const AxisMiniFill = styled.div`
+  height: 100%;
+  background-color: #9fa8da;
+  border-radius: 2px;
+  transition: width 200ms linear;
+`
+
+const AutoSceneNote = styled.div`
+  font-size: 0.8rem;
+  color: ${(p) => p.theme.colors.text.secondary};
+  font-style: italic;
+`
+
+const EmptyMessage = styled.div`
+  color: ${(p) => p.theme.colors.text.secondary};
+  font-size: 0.85rem;
+`
+
+const GroupTable = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`
+
+const GroupRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`
+
+const GroupName = styled.div`
+  width: 6rem;
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+const DepthSliderWrap = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+`
+
+const DepthLabel = styled.div`
+  font-size: 0.7rem;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const GlobalDepthRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`
+
+const GlobalDepthVal = styled.div`
+  width: 3rem;
+  font-size: 0.85rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const MapGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow-x: auto;
+`
+
+const MapHeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid ${(p) => p.theme.colors.divider};
+  padding-bottom: 0.25rem;
+  margin-bottom: 0.1rem;
+`
+
+const MapRow = styled.div<{ $vibe: VibeType }>`
+  display: flex;
+  align-items: center;
+  padding: 0.1rem 0;
+  border-radius: 2px;
+`
+
+const MapVibeLabel = styled.div<{ $hue: number }>`
+  width: 6rem;
+  font-size: 0.78rem;
+  color: ${(p) => `hsl(${Math.round(p.$hue * 360)}, 70%, 65%)`};
+  white-space: nowrap;
+`
+
+const MapCell = styled.div<{ $header?: boolean }>`
+  flex: 1;
+  min-width: 5rem;
+  font-size: ${(p) => (p.$header ? '0.7rem' : '0.72rem')};
+  color: ${(p) =>
+    p.$header ? p.theme.colors.text.secondary : p.theme.colors.text.primary};
+  text-transform: ${(p) => (p.$header ? 'uppercase' : 'none')};
+  letter-spacing: ${(p) => (p.$header ? '0.06em' : '0')};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+const EffectBadge = styled.span`
+  font-size: 0.7rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  background-color: ${(p) => p.theme.colors.bg.darker};
+  color: ${(p) => p.theme.colors.text.secondary};
+  border: 1px solid ${(p) => p.theme.colors.divider};
+`

--- a/src/renderer/redux/autoControlSlice.ts
+++ b/src/renderer/redux/autoControlSlice.ts
@@ -1,0 +1,89 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { GroupRole } from '../../shared/groupRoles'
+import { VibeBehaviorMap, DEFAULT_VIBE_BEHAVIOR_MAP } from '../../shared/vibeBehavior'
+import { VibeType } from '../../shared/audioFeatures'
+import { VibeBehavior } from '../../shared/vibeBehavior'
+
+export const AUTO_SCENE_ID = '__captivate_auto__'
+
+export interface AutoControlState {
+  enabled: boolean
+  groupRoles: Record<string, GroupRole>     // group name → role
+  behaviorMap: VibeBehaviorMap              // role → { default, vibeOverrides }
+  globalDepth: number                       // 0–1 master effect strength
+  perGroupDepth: Record<string, number>     // group → 0–1 depth override
+}
+
+function initAutoControlState(): AutoControlState {
+  return {
+    enabled: false,
+    groupRoles: {},
+    behaviorMap: DEFAULT_VIBE_BEHAVIOR_MAP,
+    globalDepth: 1,
+    perGroupDepth: {},
+  }
+}
+
+const autoControlSlice = createSlice({
+  name: 'autoControl',
+  initialState: initAutoControlState(),
+  reducers: {
+    setAutoEnabled: (state, { payload }: PayloadAction<boolean>) => {
+      state.enabled = payload
+    },
+    setGroupRole: (
+      state,
+      { payload }: PayloadAction<{ group: string; role: GroupRole }>
+    ) => {
+      state.groupRoles[payload.group] = payload.role
+    },
+    setGroupRoles: (
+      state,
+      { payload }: PayloadAction<Record<string, GroupRole>>
+    ) => {
+      state.groupRoles = payload
+    },
+    setGlobalDepth: (state, { payload }: PayloadAction<number>) => {
+      state.globalDepth = payload
+    },
+    setPerGroupDepth: (
+      state,
+      { payload }: PayloadAction<{ group: string; depth: number }>
+    ) => {
+      state.perGroupDepth[payload.group] = payload.depth
+    },
+    setVibeOverride: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        role: GroupRole
+        vibe: VibeType
+        behavior: Partial<VibeBehavior>
+      }>
+    ) => {
+      const entry = state.behaviorMap[payload.role]
+      if (entry) {
+        entry.vibeOverrides[payload.vibe] = {
+          ...(entry.vibeOverrides[payload.vibe] ?? {}),
+          ...payload.behavior,
+        }
+      }
+    },
+    resetBehaviorMap: (state) => {
+      state.behaviorMap = DEFAULT_VIBE_BEHAVIOR_MAP
+    },
+  },
+})
+
+export const {
+  setAutoEnabled,
+  setGroupRole,
+  setGroupRoles,
+  setGlobalDepth,
+  setPerGroupDepth,
+  setVibeOverride,
+  resetBehaviorMap,
+} = autoControlSlice.actions
+
+export default autoControlSlice.reducer

--- a/src/renderer/redux/controlSlice.ts
+++ b/src/renderer/redux/controlSlice.ts
@@ -22,6 +22,8 @@ import {
   SceneType,
   initSplitScene,
 } from '../../shared/Scenes'
+import { LedEffect } from '../../shared/ledPatterns'
+import { AudioModulator } from '../../shared/audioFeatures'
 import { reorderArray } from '../../shared/util'
 
 export interface ControlState extends ScenesStateBundle {
@@ -382,6 +384,31 @@ export const scenesSlice = createSlice({
         }
       })
     },
+    setLedEffect: (
+      state,
+      { payload }: PayloadAction<{ splitIndex: number; effect: LedEffect }>
+    ) => {
+      modifyActiveLightScene(state, (scene) => {
+        scene.splitScenes[payload.splitIndex].ledEffect = payload.effect
+      })
+    },
+    setAudioModulators: (
+      state,
+      { payload }: PayloadAction<AudioModulator[]>
+    ) => {
+      modifyActiveLightScene(state, (scene) => {
+        scene.audioModulators = payload
+      })
+    },
+    setLightSceneById: (
+      state,
+      { payload }: PayloadAction<{ id: string; scene: LightScene_t }>
+    ) => {
+      if (!state.light.ids.includes(payload.id)) {
+        state.light.ids.push(payload.id)
+      }
+      state.light.byId[payload.id] = payload.scene
+    },
     // =====================   VISUAL SCENES ONLY   ===========================
     resetVisualScenes: (state, { payload }: PayloadAction<VisualScenes_t>) => {
       state.visual = payload
@@ -492,6 +519,9 @@ export const {
   addSplitScene,
   removeSplitSceneByIndex,
   setSceneGroup,
+  setLedEffect,
+  setAudioModulators,
+  setLightSceneById,
 
   // VISUAL SCENES
   resetVisualScenes,

--- a/src/renderer/redux/guiSlice.ts
+++ b/src/renderer/redux/guiSlice.ts
@@ -17,6 +17,8 @@ export type Page =
   | 'Mixer'
   | 'Led'
   | 'WledMixer'
+  | 'Audio'
+  | 'AutoControl'
 
 export interface GuiState {
   activePage: Page
@@ -30,6 +32,7 @@ export interface GuiState {
   newProjectDialog: boolean
   ledEnabled: boolean
   videoEnabled: boolean
+  audioEnabled: boolean
 }
 
 export function initGuiState(): GuiState {
@@ -45,6 +48,7 @@ export function initGuiState(): GuiState {
     newProjectDialog: false,
     ledEnabled: false,
     videoEnabled: false,
+    audioEnabled: false,
   }
 }
 
@@ -85,6 +89,9 @@ export const guiSlice = createSlice({
     toggleVideoEnabled: (state, _: PayloadAction<undefined>) => {
       state.videoEnabled = !state.videoEnabled
     },
+    toggleAudioEnabled: (state, _: PayloadAction<undefined>) => {
+      state.audioEnabled = !state.audioEnabled
+    },
   },
 })
 
@@ -100,6 +107,7 @@ export const {
   setNewProjectDialog,
   toggleLedEnabled,
   toggleVideoEnabled,
+  toggleAudioEnabled,
 } = guiSlice.actions
 
 export default guiSlice.reducer

--- a/src/renderer/redux/realtimeStore.ts
+++ b/src/renderer/redux/realtimeStore.ts
@@ -10,6 +10,7 @@ import { initTimeState, TimeState } from '../../shared/TimeState'
 import { defaultOutputParams, DefaultParam, Params } from '../../shared/params'
 import { RandomizerState } from '../../shared/randomizer'
 import { BaseColors } from '../../shared/baseColors'
+import { AudioFeatures, initAudioFeatures } from '../../shared/audioFeatures'
 
 function initDmxOut(): number[] {
   return Array(512).fill(0)
@@ -25,6 +26,7 @@ export interface RealtimeState {
   dmxOut: number[]
   splitStates: SplitState[]
   wledOut: { [mdns: string]: BaseColors[] }
+  audioFeatures: AudioFeatures
 }
 
 export function initRealtimeState(): RealtimeState {
@@ -33,6 +35,7 @@ export function initRealtimeState(): RealtimeState {
     dmxOut: initDmxOut(),
     splitStates: [],
     wledOut: {},
+    audioFeatures: initAudioFeatures(),
   }
 }
 
@@ -48,7 +51,12 @@ function realtimeStoreReducer(
   action: PayloadAction<any>
 ) {
   if (action.type === 'update') {
-    return action.payload
+    // Preserve renderer-side audioFeatures — they are computed locally via Web Audio API
+    // and must not be overwritten by the main-process IPC state update
+    return { ...action.payload, audioFeatures: state.audioFeatures }
+  }
+  if (action.type === 'updateAudioFeatures') {
+    return { ...state, audioFeatures: action.payload }
   }
   return state
 }

--- a/src/renderer/redux/store.ts
+++ b/src/renderer/redux/store.ts
@@ -8,6 +8,7 @@ import { useSelector, TypedUseSelectorHook } from 'react-redux'
 import dmxReducer, { DmxState } from './dmxSlice'
 import guiReducer from './guiSlice'
 import controlReducer, { ControlState } from './controlSlice'
+import autoControlReducer from './autoControlSlice'
 import { LightScene_t } from '../../shared/Scenes'
 import mixerReducer from './mixerSlice'
 import undoable, { StateWithHistory } from 'redux-undo'
@@ -46,6 +47,7 @@ const baseReducer = combineReducers({
     redoType: undoActionTypes.control.redo,
   }),
   mixer: mixerReducer,
+  autoControl: autoControlReducer,
 })
 
 export type ReduxState = ReturnType<typeof baseReducer>
@@ -104,6 +106,7 @@ const rootReducer: Reducer<ReduxState, PayloadAction<any>> = (
       gui: cleanState.gui,
       control: initUndoState(cleanState.control),
       mixer: cleanState.mixer,
+      autoControl: cleanState.autoControl,
     }
   } else if (action.type === RESET_UNIVERSE) {
     const us: DmxState = action.payload
@@ -192,6 +195,7 @@ export function getCleanReduxState(state: ReduxState) {
     gui: state.gui,
     control: state.control.present,
     mixer: state.mixer,
+    autoControl: state.autoControl,
   }
 }
 

--- a/src/renderer/scenes/LedEffectControl.tsx
+++ b/src/renderer/scenes/LedEffectControl.tsx
@@ -1,0 +1,142 @@
+import styled from 'styled-components'
+import { useDispatch } from 'react-redux'
+import { useActiveLightScene } from 'renderer/redux/store'
+import { setLedEffect } from 'renderer/redux/controlSlice'
+import {
+  LED_EFFECT_TYPES,
+  LedEffect,
+  LedEffectType,
+  initLedEffect,
+} from 'shared/ledPatterns'
+import Slider from '@mui/material/Slider'
+import Select from '@mui/material/Select'
+import MenuItem from '@mui/material/MenuItem'
+
+// Effect types that use the speed slider
+const TIME_BASED: LedEffectType[] = [
+  'chase', 'pulse', 'strobe', 'colorwave', 'breathe',
+]
+
+const EFFECT_LABELS: Record<LedEffectType, string> = {
+  none: 'None',
+  chase: 'Chase',
+  pulse: 'Pulse',
+  strobe: 'Strobe',
+  sparkle: 'Sparkle',
+  gradient: 'Gradient',
+  colorwave: 'Color Wave',
+  breathe: 'Breathe',
+  mirror: 'Mirror',
+  lightning: 'Lightning',
+}
+
+interface Props {
+  splitIndex: number
+}
+
+export default function LedEffectControl({ splitIndex }: Props) {
+  const dispatch = useDispatch()
+  const effect: LedEffect = useActiveLightScene(
+    (scene) => scene.splitScenes[splitIndex]?.ledEffect ?? initLedEffect()
+  )
+
+  function update(patch: Partial<LedEffect>) {
+    dispatch(setLedEffect({ splitIndex, effect: { ...effect, ...patch } }))
+  }
+
+  const showSpeed = TIME_BASED.includes(effect.type)
+
+  return (
+    <Root>
+      <Label>LED Effect</Label>
+      <Row>
+        <Select
+          size="small"
+          value={effect.type}
+          onChange={(e) => update({ type: e.target.value as LedEffectType })}
+          sx={{ fontSize: '0.85rem', minWidth: '9rem' }}
+        >
+          {LED_EFFECT_TYPES.map((t) => (
+            <MenuItem key={t} value={t} sx={{ fontSize: '0.85rem' }}>
+              {EFFECT_LABELS[t]}
+            </MenuItem>
+          ))}
+        </Select>
+      </Row>
+
+      {effect.type !== 'none' && (
+        <>
+          <SliderRow>
+            <SliderLabel>Intensity</SliderLabel>
+            <Slider
+              size="small"
+              min={0}
+              max={1}
+              step={0.01}
+              value={effect.intensity}
+              onChange={(_, v) => update({ intensity: v as number })}
+              sx={{ flex: 1 }}
+            />
+            <SliderValue>{Math.round(effect.intensity * 100)}%</SliderValue>
+          </SliderRow>
+
+          {showSpeed && (
+            <SliderRow>
+              <SliderLabel>Speed</SliderLabel>
+              <Slider
+                size="small"
+                min={0}
+                max={1}
+                step={0.01}
+                value={effect.speed}
+                onChange={(_, v) => update({ speed: v as number })}
+                sx={{ flex: 1 }}
+              />
+              <SliderValue>{Math.round(effect.speed * 100)}%</SliderValue>
+            </SliderRow>
+          )}
+        </>
+      )}
+    </Root>
+  )
+}
+
+const Root = styled.div`
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+`
+
+const Label = styled.div`
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`
+
+const SliderRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`
+
+const SliderLabel = styled.div`
+  width: 4rem;
+  font-size: 0.8rem;
+  color: ${(p) => p.theme.colors.text.secondary};
+`
+
+const SliderValue = styled.div`
+  width: 2.5rem;
+  font-size: 0.8rem;
+  text-align: right;
+  color: ${(p) => p.theme.colors.text.secondary};
+  font-variant-numeric: tabular-nums;
+`

--- a/src/renderer/scenes/SplitScenes.tsx
+++ b/src/renderer/scenes/SplitScenes.tsx
@@ -1,8 +1,13 @@
 import ParamsControl from 'renderer/controls/ParamsControl'
-import { useActiveLightScene, useControlSelector } from 'renderer/redux/store'
+import {
+  useActiveLightScene,
+  useControlSelector,
+  useTypedSelector,
+} from 'renderer/redux/store'
 import { indexArray } from 'shared/util'
 import styled from 'styled-components'
 import GroupSelection from './GroupSelection'
+import LedEffectControl from './LedEffectControl'
 import Button from '@mui/material/Button'
 import AddIcon from '@mui/icons-material/Add'
 import IconButton from '@mui/material/IconButton'
@@ -47,10 +52,12 @@ interface Props {
 }
 
 function SplitScene({ index }: Props) {
+  const ledEnabled = useTypedSelector((state) => state.gui.ledEnabled)
   return (
     <Root2>
       <GroupSelection splitIndex={index} />
       <ParamsControl splitIndex={index} />
+      {ledEnabled && <LedEffectControl splitIndex={index} />}
     </Root2>
   )
 }

--- a/src/shared/Scenes.ts
+++ b/src/shared/Scenes.ts
@@ -10,6 +10,8 @@ import {
   EffectsConfig,
   initEffectsConfig,
 } from '../visualizer/threejs/effects/effectConfigs'
+import { LedEffect } from './ledPatterns'
+import { AudioModulator } from './audioFeatures'
 
 export interface SceneBase {
   name: string
@@ -22,6 +24,7 @@ export interface SplitScene_t {
   randomizer: RandomizerOptions
   // true = include group | false = include not group
   groups: { [key: string]: boolean | undefined }
+  ledEffect?: LedEffect
 }
 
 export function initSplitScene(): SplitScene_t {
@@ -35,6 +38,7 @@ export function initSplitScene(): SplitScene_t {
 export interface LightScene_t extends SceneBase {
   modulators: Modulator[]
   splitScenes: SplitScene_t[]
+  audioModulators?: AudioModulator[]
 }
 
 export function initLightScene(): LightScene_t {

--- a/src/shared/audioFeatures.ts
+++ b/src/shared/audioFeatures.ts
@@ -1,0 +1,166 @@
+// ── Vibe Axes ────────────────────────────────────────────────────────────────
+// 5 musical-character axes computed from raw FFT features.
+// Each axis is 0–1 and smoothed with a slow EMA (~2s) before vibe classification.
+
+export interface VibeAxes {
+  heat: number      // 0 = cool/bright/treble-heavy  →  1 = warm/bass-heavy
+  energy: number    // 0 = ambient/silence           →  1 = intense/loud
+  pulse: number     // 0 = smooth/flowing             →  1 = punchy/percussive
+  groove: number    // 0 = sparse/minimal             →  1 = mid-rich/syncopated
+  momentum: number  // 0 = resolving/falling          →  1 = building/rising
+}
+
+export function initVibeAxes(): VibeAxes {
+  return { heat: 0.5, energy: 0, pulse: 0, groove: 0.5, momentum: 0.5 }
+}
+
+// ── 20 Named Vibes ───────────────────────────────────────────────────────────
+
+export type VibeType =
+  | 'deep'      // low-energy, cool, minimal — late-night techno baseline
+  | 'chill'     // calm, neutral warmth, no pulse — lounge/downtempo
+  | 'float'     // very low energy, airy — ambient/chillwave
+  | 'groove'    // medium energy, warm, syncopated — house/funk
+  | 'funk'      // high energy, very warm, punchy — funky/syncopated
+  | 'soul'      // medium energy, warm, smooth — R&B/soul
+  | 'drive'     // high energy, cool, driving — progressive techno
+  | 'pulse'     // high energy, strong regular beat — EDM/4-on-floor
+  | 'rave'      // maximum energy, cool, rapid — hard techno/gabber feel
+  | 'build'     // rising momentum — pre-drop buildup
+  | 'drop'      // peak everything — the drop
+  | 'breakdown' // post-drop sparse — breakdown/outro
+  | 'tropical'  // warm, energetic, syncopated — afrobeats/tropical house
+  | 'dark'      // medium energy, cool, heavy — dark techno/industrial
+  | 'bright'    // medium energy, cool/treble-bright — pop/euphoric trance
+  | 'snappy'    // fast, percussive, complex — DnB/jungle
+  | 'smooth'    // flowing, warm, melodic — smooth jazz/slow RnB
+  | 'epic'      // massive, building — stadium trance/epic
+  | 'intimate'  // very quiet, sparse, delicate — acoustic/ballad
+  | 'neutral'   // average — when no strong character detected
+
+export const VIBE_TYPES: VibeType[] = [
+  'deep', 'chill', 'float', 'groove', 'funk', 'soul',
+  'drive', 'pulse', 'rave', 'build', 'drop', 'breakdown',
+  'tropical', 'dark', 'bright', 'snappy', 'smooth', 'epic',
+  'intimate', 'neutral',
+]
+
+// Named centroids in [heat, energy, pulse, groove, momentum] space
+export const VIBE_CENTROIDS: Record<VibeType, VibeAxes> = {
+  deep:      { heat: 0.30, energy: 0.20, pulse: 0.30, groove: 0.40, momentum: 0.40 },
+  chill:     { heat: 0.50, energy: 0.20, pulse: 0.20, groove: 0.30, momentum: 0.30 },
+  float:     { heat: 0.50, energy: 0.10, pulse: 0.10, groove: 0.20, momentum: 0.30 },
+  groove:    { heat: 0.70, energy: 0.50, pulse: 0.50, groove: 0.80, momentum: 0.50 },
+  funk:      { heat: 0.80, energy: 0.70, pulse: 0.70, groove: 0.90, momentum: 0.50 },
+  soul:      { heat: 0.70, energy: 0.50, pulse: 0.40, groove: 0.70, momentum: 0.40 },
+  drive:     { heat: 0.30, energy: 0.70, pulse: 0.60, groove: 0.50, momentum: 0.70 },
+  pulse:     { heat: 0.40, energy: 0.80, pulse: 0.90, groove: 0.50, momentum: 0.50 },
+  rave:      { heat: 0.20, energy: 0.90, pulse: 0.90, groove: 0.60, momentum: 0.60 },
+  build:     { heat: 0.40, energy: 0.60, pulse: 0.60, groove: 0.50, momentum: 0.90 },
+  drop:      { heat: 0.50, energy: 1.00, pulse: 1.00, groove: 0.70, momentum: 0.50 },
+  breakdown: { heat: 0.50, energy: 0.20, pulse: 0.20, groove: 0.30, momentum: 0.10 },
+  tropical:  { heat: 0.80, energy: 0.60, pulse: 0.60, groove: 0.80, momentum: 0.50 },
+  dark:      { heat: 0.20, energy: 0.60, pulse: 0.50, groove: 0.40, momentum: 0.50 },
+  bright:    { heat: 0.30, energy: 0.60, pulse: 0.50, groove: 0.50, momentum: 0.50 },
+  snappy:    { heat: 0.50, energy: 0.80, pulse: 0.90, groove: 0.90, momentum: 0.60 },
+  smooth:    { heat: 0.60, energy: 0.40, pulse: 0.20, groove: 0.50, momentum: 0.40 },
+  epic:      { heat: 0.40, energy: 0.90, pulse: 0.70, groove: 0.60, momentum: 0.80 },
+  intimate:  { heat: 0.60, energy: 0.10, pulse: 0.10, groove: 0.20, momentum: 0.30 },
+  neutral:   { heat: 0.50, energy: 0.40, pulse: 0.40, groove: 0.40, momentum: 0.40 },
+}
+
+// Nearest-centroid classification (Euclidean distance in 5D)
+export function classifyVibe(axes: VibeAxes): VibeType {
+  let bestVibe: VibeType = 'neutral'
+  let bestDist = Infinity
+  for (const vibe of VIBE_TYPES) {
+    const c = VIBE_CENTROIDS[vibe]
+    const d =
+      (axes.heat - c.heat) ** 2 +
+      (axes.energy - c.energy) ** 2 +
+      (axes.pulse - c.pulse) ** 2 +
+      (axes.groove - c.groove) ** 2 +
+      (axes.momentum - c.momentum) ** 2
+    if (d < bestDist) {
+      bestDist = d
+      bestVibe = vibe
+    }
+  }
+  return bestVibe
+}
+
+// Suggested hue (0–1) for each vibe — used as default hueOverride in behavior map
+export const VIBE_HUE: Record<VibeType, number> = {
+  deep:      0.65, // dark blue
+  chill:     0.55, // teal
+  float:     0.72, // soft purple
+  groove:    0.08, // warm amber
+  funk:      0.06, // orange
+  soul:      0.02, // deep red-orange
+  drive:     0.60, // electric blue
+  pulse:     0.50, // cyan
+  rave:      0.75, // ultraviolet
+  build:     0.28, // yellow-green
+  drop:      0.00, // pure white/red burst
+  breakdown: 0.65, // muted blue
+  tropical:  0.38, // lime-teal
+  dark:      0.80, // dark violet
+  bright:    0.85, // electric pink
+  snappy:    0.33, // neon green
+  smooth:    0.05, // soft salmon-red
+  epic:      0.12, // gold
+  intimate:  0.07, // warm amber dim
+  neutral:   0.55, // white/neutral teal
+}
+
+// ── AudioFeatures ─────────────────────────────────────────────────────────────
+
+export interface AudioFeatures {
+  enabled: boolean
+  energy: number    // 0–1 RMS overall
+  bass: number      // 0–1 RMS 20–250 Hz
+  mids: number      // 0–1 RMS 250–4000 Hz
+  treble: number    // 0–1 RMS 4000–20000 Hz
+  centroid: number  // 0–1 spectral centroid (normalized to Nyquist)
+  flux: number      // 0–1 spectral flux (half-wave rectified frame delta)
+  onset: number     // 0–1 onset strength (percussive attack detector)
+  drop: boolean     // true when energy drops ≥50% after a build
+  bpm: number       // detected BPM from onset autocorrelation, or 0
+  // Vibe system
+  vibeAxes: VibeAxes
+  vibe: VibeType
+}
+
+export function initAudioFeatures(): AudioFeatures {
+  return {
+    enabled: false,
+    energy: 0,
+    bass: 0,
+    mids: 0,
+    treble: 0,
+    centroid: 0,
+    flux: 0,
+    onset: 0,
+    drop: false,
+    bpm: 0,
+    vibeAxes: initVibeAxes(),
+    vibe: 'neutral',
+  }
+}
+
+export type AudioFeatureKey =
+  | 'energy'
+  | 'bass'
+  | 'mids'
+  | 'treble'
+  | 'centroid'
+  | 'flux'
+  | 'onset'
+
+export interface AudioModulator {
+  source: AudioFeatureKey
+  target: string    // DefaultParam key e.g. 'brightness', 'hue', 'saturation'
+  min: number       // output range min 0–1
+  max: number       // output range max 0–1
+  smoothing: number // 0–1 exponential moving average applied before mapping
+}

--- a/src/shared/groupRoles.ts
+++ b/src/shared/groupRoles.ts
@@ -1,0 +1,77 @@
+import { AudioModulator } from './audioFeatures'
+
+export type GroupRole =
+  | 'dancefloor'    // strong bass/beat response, LED chase/sparkle
+  | 'stroboscope'   // strobe-only, fires on high energy/onset moments
+  | 'laser'         // sharp snappy effects, onset-triggered
+  | 'scanner'       // sweeping, beat-synced movement
+  | 'background'    // ambient wash/fill, mood color, subtle energy response
+  | 'ambient'       // very smooth, color from mood, slow changes
+  | 'effect'        // flexible vibe-specific fixture
+  | 'beam'          // sweeping beam, energy + mids driven
+  | 'off'           // no auto-control for this group
+
+export const GROUP_ROLES: GroupRole[] = [
+  'off', 'dancefloor', 'stroboscope', 'laser', 'scanner',
+  'background', 'ambient', 'effect', 'beam',
+]
+
+export const GROUP_ROLE_LABELS: Record<GroupRole, string> = {
+  off:         'Off',
+  dancefloor:  'Dancefloor',
+  stroboscope: 'Stroboscope',
+  laser:       'Laser',
+  scanner:     'Scanner',
+  background:  'Background',
+  ambient:     'Ambient',
+  effect:      'Effect',
+  beam:        'Beam',
+}
+
+export const GROUP_ROLE_DESCRIPTIONS: Record<GroupRole, string> = {
+  off:         'No auto-control for this group',
+  dancefloor:  'Primary surface — strong beat/bass response, LED patterns',
+  stroboscope: 'Strobe-only — fires on high energy and drops',
+  laser:       'Sharp fast effects — onset-triggered, snappy response',
+  scanner:     'Sweeping motion — smooth beat-synced movement',
+  background:  'Ambient wash — slow mood color, subtle energy response',
+  ambient:     'Very smooth — reflects mood only, ignores beat',
+  effect:      'Flexible — vibe-specific special effect fixture',
+  beam:        'Moving beam — sweeps with mids and energy',
+}
+
+// Legacy: pre-baked AudioModulator presets per role (used by old Auto Control page)
+export const GROUP_ROLE_PRESETS: Record<GroupRole, AudioModulator[]> = {
+  off:         [],
+  dancefloor: [
+    { source: 'bass', target: 'brightness', min: 0.05, max: 1.0, smoothing: 0.3 },
+    { source: 'onset', target: 'brightness', min: 0.0, max: 1.0, smoothing: 0.05 },
+  ],
+  stroboscope: [
+    { source: 'onset', target: 'brightness', min: 0.0, max: 1.0, smoothing: 0.05 },
+  ],
+  laser: [
+    { source: 'onset', target: 'brightness', min: 0.0, max: 1.0, smoothing: 0.1 },
+    { source: 'flux', target: 'brightness', min: 0.0, max: 1.0, smoothing: 0.1 },
+  ],
+  scanner: [
+    { source: 'mids', target: 'hue', min: 0.0, max: 0.5, smoothing: 0.6 },
+    { source: 'energy', target: 'brightness', min: 0.2, max: 0.9, smoothing: 0.5 },
+  ],
+  background: [
+    { source: 'energy', target: 'saturation', min: 0.3, max: 1.0, smoothing: 0.8 },
+    { source: 'energy', target: 'brightness', min: 0.2, max: 0.7, smoothing: 0.9 },
+  ],
+  ambient: [
+    { source: 'energy', target: 'saturation', min: 0.2, max: 0.8, smoothing: 0.95 },
+    { source: 'energy', target: 'brightness', min: 0.1, max: 0.5, smoothing: 0.95 },
+  ],
+  effect: [
+    { source: 'onset', target: 'brightness', min: 0.0, max: 1.0, smoothing: 0.1 },
+    { source: 'flux', target: 'brightness', min: 0.1, max: 0.9, smoothing: 0.2 },
+  ],
+  beam: [
+    { source: 'mids', target: 'hue', min: 0.0, max: 0.5, smoothing: 0.5 },
+    { source: 'treble', target: 'brightness', min: 0.1, max: 0.8, smoothing: 0.4 },
+  ],
+}

--- a/src/shared/ipc_channels.ts
+++ b/src/shared/ipc_channels.ts
@@ -13,6 +13,7 @@ export default {
   main_command: 'main_command',
   test_wled_connection: 'test_wled_connection',
   reset_wled_protocol: 'reset_wled_protocol',
+  audio_features: 'audio_features',
 } as const
 
 export interface SetLinkEnabled {

--- a/src/shared/ledPatterns.ts
+++ b/src/shared/ledPatterns.ts
@@ -1,0 +1,260 @@
+import { BaseColors, getBaseColorsFromHsv } from './baseColors'
+import { TimeState } from './TimeState'
+
+export type LedEffectType =
+  | 'none'
+  | 'chase'
+  | 'pulse'
+  | 'strobe'
+  | 'sparkle'
+  | 'gradient'
+  | 'colorwave'
+  | 'breathe'
+  | 'mirror'
+  | 'lightning'
+
+export interface LedEffect {
+  type: LedEffectType
+  speed: number    // 0–1  how fast the effect animates
+  intensity: number // 0–1  effect strength / density
+}
+
+export function initLedEffect(): LedEffect {
+  return { type: 'none', speed: 0.5, intensity: 0.5 }
+}
+
+export const LED_EFFECT_TYPES: LedEffectType[] = [
+  'none', 'chase', 'pulse', 'strobe', 'sparkle',
+  'gradient', 'colorwave', 'breathe', 'mirror', 'lightning',
+]
+
+// ---------------------------------------------------------------------------
+// Apply effect post-processing to a base color array
+// colors: array of BaseColors from getLedValues(), length = led_count
+// baseHue: scene hue (0–1) used by color-generating effects
+// Returns a new array of the same length.
+// ---------------------------------------------------------------------------
+export function applyLedEffect(
+  colors: BaseColors[],
+  effect: LedEffect,
+  timeState: TimeState,
+  baseHue: number
+): BaseColors[] {
+  switch (effect.type) {
+    case 'chase':     return applyChase(colors, effect, timeState)
+    case 'pulse':     return applyPulse(colors, effect, timeState)
+    case 'strobe':    return applyStrobe(colors, effect, timeState)
+    case 'sparkle':   return applySparkle(colors, effect)
+    case 'gradient':  return applyGradient(colors, effect, baseHue)
+    case 'colorwave': return applyColorwave(colors, effect, timeState, baseHue)
+    case 'breathe':   return applyBreathe(colors, effect, timeState)
+    case 'mirror':    return applyMirror(colors)
+    case 'lightning': return applyLightning(colors, effect, baseHue)
+    default:          return colors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function scale(c: BaseColors, m: number): BaseColors {
+  return { red: c.red * m, green: c.green * m, blue: c.blue * m }
+}
+
+// Fractional part of a number, always positive
+function frac(x: number): number {
+  return x - Math.floor(x)
+}
+
+// Low-quality but fast deterministic pseudo-random (seeded by index + salt)
+function hash(n: number): number {
+  n = ((n >> 16) ^ n) * 0x45d9f3b
+  n = ((n >> 16) ^ n) * 0x45d9f3b
+  return ((n >> 16) ^ n) >>> 0
+}
+
+function pseudoRand(seed: number): number {
+  return hash(seed) / 0xffffffff
+}
+
+function brightness(c: BaseColors): number {
+  return (c.red + c.green + c.blue) / 3
+}
+
+// ---------------------------------------------------------------------------
+// Chase — a lit window scrolls along the strip, BPM-synced
+// speed controls window width (0 = narrow, 1 = wide)
+// intensity controls brightness outside the window (0 = full off, 1 = full on)
+// ---------------------------------------------------------------------------
+function applyChase(
+  colors: BaseColors[],
+  effect: LedEffect,
+  timeState: TimeState
+): BaseColors[] {
+  const n = colors.length
+  if (n === 0) return colors
+  const windowWidth = 0.1 + effect.speed * 0.4 // 10%–50% of strip
+  // position follows beat phase 0–1
+  const pos = frac(timeState.beats / 4)
+  return colors.map((c, i) => {
+    const ledPos = i / n
+    const dist = Math.abs(frac(ledPos - pos + 0.5) - 0.5)
+    const inWindow = dist < windowWidth / 2
+    const mult = inWindow ? 1.0 : effect.intensity * 0.15
+    return scale(c, mult)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Pulse — brightness pulses in/out on beat
+// speed controls pulse sharpness (0 = smooth, 1 = snappy)
+// intensity controls minimum brightness
+// ---------------------------------------------------------------------------
+function applyPulse(
+  colors: BaseColors[],
+  effect: LedEffect,
+  timeState: TimeState
+): BaseColors[] {
+  const beatPhase = frac(timeState.beats) // 0–1 within a beat
+  const sharpness = 1 + effect.speed * 8
+  const pulse = Math.pow(1 - beatPhase, sharpness)
+  const mult = effect.intensity + (1 - effect.intensity) * pulse
+  return colors.map((c) => scale(c, mult))
+}
+
+// ---------------------------------------------------------------------------
+// Strobe — full on/off flash
+// speed controls strobe rate (0 = 1× beat, 1 = 8× beat)
+// intensity controls on-duty-cycle
+// ---------------------------------------------------------------------------
+function applyStrobe(
+  colors: BaseColors[],
+  effect: LedEffect,
+  timeState: TimeState
+): BaseColors[] {
+  const subdivisions = 1 + Math.round(effect.speed * 7) // 1–8 per beat
+  const phase = frac(timeState.beats * subdivisions)
+  const duty = 0.1 + effect.intensity * 0.5 // 10%–60% on
+  const on = phase < duty
+  return on ? colors : colors.map(() => ({ red: 0, green: 0, blue: 0 }))
+}
+
+// ---------------------------------------------------------------------------
+// Sparkle — random LEDs flash brighter
+// speed controls flash decay rate
+// intensity controls density (fraction of LEDs active)
+// ---------------------------------------------------------------------------
+function applySparkle(colors: BaseColors[], effect: LedEffect): BaseColors[] {
+  const density = effect.intensity
+  const brightness = 0.5 + effect.speed * 0.5
+  return colors.map((c, i) => {
+    const r = pseudoRand(i + Math.floor(Date.now() / 80))
+    return r < density ? scale(c, 1 + brightness) : c
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Gradient — N colors near baseHue spread along the strip
+// intensity → numColors (1–5 distinct hue bands)
+// speed → spread between colors (0 = tight cluster, 1 = quarter wheel apart)
+// ---------------------------------------------------------------------------
+function applyGradient(
+  colors: BaseColors[],
+  effect: LedEffect,
+  baseHue: number
+): BaseColors[] {
+  const n = colors.length
+  if (n === 0) return colors
+  const numColors = 1 + Math.round(effect.intensity * 4) // 1–5
+  const spread = effect.speed * 0.25 // max 0.25 of color wheel between adjacent bands
+  return colors.map((c, i) => {
+    const segment = Math.floor((i / n) * numColors)
+    const hue = frac(baseHue + segment * spread)
+    const bri = brightness(c)
+    const sat = bri > 0.01 ? 1.0 : 0
+    const out = getBaseColorsFromHsv(hue, sat, Math.min(bri * 3, 1))
+    return { red: Math.min(out.red, 1), green: Math.min(out.green, 1), blue: Math.min(out.blue, 1) }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Colorwave — sinusoidal hue oscillation around baseHue
+// intensity → hue oscillation depth (0 = no variation, 1 = ±15% of wheel)
+// speed → wave travel rate
+// ---------------------------------------------------------------------------
+function applyColorwave(
+  colors: BaseColors[],
+  effect: LedEffect,
+  timeState: TimeState,
+  baseHue: number
+): BaseColors[] {
+  const n = colors.length
+  if (n === 0) return colors
+  const spread = effect.intensity * 0.15 // max ±15% of color wheel
+  const phase = timeState.beats * effect.speed
+  return colors.map((c, i) => {
+    const wave = Math.sin((i / n) * Math.PI * 2 + phase * Math.PI * 2)
+    const hue = frac(baseHue + wave * spread)
+    const bri = brightness(c)
+    const sat = bri > 0.01 ? 1.0 : 0
+    const out = getBaseColorsFromHsv(hue, sat, Math.min(bri * 3, 1))
+    return { red: Math.min(out.red, 1), green: Math.min(out.green, 1), blue: Math.min(out.blue, 1) }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Breathe — slow sinusoidal brightness envelope, ignores beat sync
+// speed controls breath rate (in beats per breath)
+// intensity controls minimum brightness
+// ---------------------------------------------------------------------------
+function applyBreathe(
+  colors: BaseColors[],
+  effect: LedEffect,
+  timeState: TimeState
+): BaseColors[] {
+  const beatsPerBreath = 2 + (1 - effect.speed) * 6 // 2–8 beats per breath
+  const phase = frac(timeState.beats / beatsPerBreath)
+  const mult = effect.intensity + (1 - effect.intensity) * (0.5 + 0.5 * Math.sin(phase * Math.PI * 2))
+  return colors.map((c) => scale(c, mult))
+}
+
+// ---------------------------------------------------------------------------
+// Mirror — reflect left half onto right half (or right onto left)
+// ---------------------------------------------------------------------------
+function applyMirror(colors: BaseColors[]): BaseColors[] {
+  const n = colors.length
+  if (n < 2) return colors
+  const half = Math.floor(n / 2)
+  const out = [...colors]
+  for (let i = 0; i < half; i++) {
+    out[n - 1 - i] = out[i]
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Lightning — random subset of LEDs pop bright; rest keep base color
+// intensity → fraction of LEDs struck per strike (0.05–0.5)
+// speed → strike frequency (how often a strike occurs)
+// ---------------------------------------------------------------------------
+function applyLightning(
+  colors: BaseColors[],
+  effect: LedEffect,
+  baseHue: number
+): BaseColors[] {
+  const n = colors.length
+  if (n === 0) return colors
+  const now = Date.now()
+  const strikeWindow = Math.round(30 + (1 - effect.speed) * 270) // ms between strikes: 30–300
+  const slot = Math.floor(now / strikeWindow)
+  // Use slot as seed — only 10% of slots produce a strike
+  if (pseudoRand(slot) > 0.1) return colors
+
+  const fraction = 0.05 + effect.intensity * 0.45 // 5%–50% of LEDs
+  const flashColor = getBaseColorsFromHsv(baseHue, 0.3, 1) // near-white tinted by baseHue
+  return colors.map((c, i) => {
+    // deterministic per-LED per-slot: flash if this LED is in the struck subset
+    return pseudoRand(slot * 10000 + i) < fraction ? flashColor : c
+  })
+}

--- a/src/shared/vibeBehavior.ts
+++ b/src/shared/vibeBehavior.ts
@@ -1,0 +1,229 @@
+import { LedEffect } from './ledPatterns'
+import { VibeType } from './audioFeatures'
+import { GroupRole } from './groupRoles'
+
+// ---------------------------------------------------------------------------
+// VibeBehavior — what a fixture group does for a given vibe
+// ---------------------------------------------------------------------------
+export interface VibeBehavior {
+  ledEffect: LedEffect
+  hueOverride?: number   // 0–1; if set, overrides the scene's base hue
+  saturation: number     // 0–1
+  brightness: number     // 0–1 base brightness before globalDepth scaling
+}
+
+// Per-role entry: a default behavior plus optional per-vibe overrides
+export interface RoleBehaviorEntry {
+  default: VibeBehavior
+  vibeOverrides: Partial<Record<VibeType, Partial<VibeBehavior>>>
+}
+
+export type VibeBehaviorMap = Partial<Record<GroupRole, RoleBehaviorEntry>>
+
+// ---------------------------------------------------------------------------
+// Merge a per-vibe override on top of the role default
+// ---------------------------------------------------------------------------
+export function resolveBehavior(
+  role: GroupRole,
+  vibe: VibeType,
+  map: VibeBehaviorMap
+): VibeBehavior {
+  const entry = map[role]
+  if (!entry) return FALLBACK_BEHAVIOR
+  const override = entry.vibeOverrides[vibe] ?? {}
+  return { ...entry.default, ...override }
+}
+
+// ---------------------------------------------------------------------------
+// Fallback used when role has no entry
+// ---------------------------------------------------------------------------
+const FALLBACK_BEHAVIOR: VibeBehavior = {
+  ledEffect: { type: 'none', speed: 0.5, intensity: 0.5 },
+  saturation: 1,
+  brightness: 0.5,
+}
+
+// ---------------------------------------------------------------------------
+// DEFAULT_VIBE_BEHAVIOR_MAP
+// One entry per GroupRole, with role-level defaults and key vibe overrides.
+// ---------------------------------------------------------------------------
+export const DEFAULT_VIBE_BEHAVIOR_MAP: VibeBehaviorMap = {
+
+  // ── Dancefloor ────────────────────────────────────────────────────────────
+  // Primary lighting surface — strongly reactive to beat/energy
+  dancefloor: {
+    default: {
+      ledEffect: { type: 'chase', speed: 0.5, intensity: 0.4 },
+      saturation: 1,
+      brightness: 0.7,
+    },
+    vibeOverrides: {
+      deep:      { ledEffect: { type: 'pulse', speed: 0.3, intensity: 0.3 }, brightness: 0.4 },
+      chill:     { ledEffect: { type: 'breathe', speed: 0.3, intensity: 0.3 }, brightness: 0.35 },
+      float:     { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.2 }, brightness: 0.25 },
+      groove:    { ledEffect: { type: 'chase', speed: 0.5, intensity: 0.5 }, brightness: 0.7, hueOverride: 0.08 },
+      funk:      { ledEffect: { type: 'sparkle', speed: 0.7, intensity: 0.6 }, brightness: 0.85, hueOverride: 0.06 },
+      soul:      { ledEffect: { type: 'breathe', speed: 0.5, intensity: 0.5 }, brightness: 0.6, hueOverride: 0.02 },
+      drive:     { ledEffect: { type: 'chase', speed: 0.7, intensity: 0.4 }, brightness: 0.8 },
+      pulse:     { ledEffect: { type: 'pulse', speed: 0.8, intensity: 0.3 }, brightness: 0.9 },
+      rave:      { ledEffect: { type: 'strobe', speed: 0.6, intensity: 0.5 }, brightness: 1.0, hueOverride: 0.65 },
+      build:     { ledEffect: { type: 'chase', speed: 0.8, intensity: 0.6 }, brightness: 0.8 },
+      drop:      { ledEffect: { type: 'strobe', speed: 0.9, intensity: 0.6 }, brightness: 1.0 },
+      breakdown: { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.2 }, brightness: 0.25 },
+      tropical:  { ledEffect: { type: 'sparkle', speed: 0.6, intensity: 0.6 }, brightness: 0.8, hueOverride: 0.38 },
+      dark:      { ledEffect: { type: 'pulse', speed: 0.5, intensity: 0.3 }, brightness: 0.6, hueOverride: 0.80 },
+      bright:    { ledEffect: { type: 'colorwave', speed: 0.5, intensity: 0.4 }, brightness: 0.75, hueOverride: 0.85 },
+      snappy:    { ledEffect: { type: 'sparkle', speed: 0.9, intensity: 0.7 }, brightness: 0.95, hueOverride: 0.33 },
+      smooth:    { ledEffect: { type: 'colorwave', speed: 0.3, intensity: 0.2 }, brightness: 0.55, hueOverride: 0.05 },
+      epic:      { ledEffect: { type: 'chase', speed: 0.9, intensity: 0.8 }, brightness: 1.0 },
+      intimate:  { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.15 }, brightness: 0.2 },
+      neutral:   { ledEffect: { type: 'pulse', speed: 0.5, intensity: 0.4 }, brightness: 0.55 },
+    },
+  },
+
+  // ── Stroboscope ───────────────────────────────────────────────────────────
+  // Strobe-only fixture — fires on high energy/onset moments
+  stroboscope: {
+    default: {
+      ledEffect: { type: 'none', speed: 0.5, intensity: 0.5 },
+      saturation: 0,
+      brightness: 0,
+    },
+    vibeOverrides: {
+      pulse:     { ledEffect: { type: 'strobe', speed: 0.5, intensity: 0.4 }, saturation: 0, brightness: 1.0 },
+      rave:      { ledEffect: { type: 'strobe', speed: 0.8, intensity: 0.6 }, saturation: 0, brightness: 1.0 },
+      drop:      { ledEffect: { type: 'strobe', speed: 0.9, intensity: 0.7 }, saturation: 0, brightness: 1.0 },
+      build:     { ledEffect: { type: 'strobe', speed: 0.4, intensity: 0.3 }, saturation: 0, brightness: 0.9 },
+      snappy:    { ledEffect: { type: 'strobe', speed: 0.6, intensity: 0.5 }, saturation: 0, brightness: 1.0 },
+      epic:      { ledEffect: { type: 'strobe', speed: 0.5, intensity: 0.5 }, saturation: 0, brightness: 1.0 },
+      funk:      { ledEffect: { type: 'strobe', speed: 0.3, intensity: 0.3 }, saturation: 0, brightness: 0.8 },
+    },
+  },
+
+  // ── Laser ─────────────────────────────────────────────────────────────────
+  // Sharp, fast-reacting fixture
+  laser: {
+    default: {
+      ledEffect: { type: 'pulse', speed: 0.6, intensity: 0.3 },
+      saturation: 1,
+      brightness: 0.6,
+    },
+    vibeOverrides: {
+      deep:      { ledEffect: { type: 'none', speed: 0.5, intensity: 0.5 }, brightness: 0 },
+      chill:     { ledEffect: { type: 'none', speed: 0.5, intensity: 0.5 }, brightness: 0 },
+      float:     { ledEffect: { type: 'none', speed: 0.5, intensity: 0.5 }, brightness: 0 },
+      snappy:    { ledEffect: { type: 'sparkle', speed: 0.9, intensity: 0.8 }, brightness: 0.9, hueOverride: 0.60 },
+      drive:     { ledEffect: { type: 'chase', speed: 0.8, intensity: 0.5 }, brightness: 0.85, hueOverride: 0.60 },
+      rave:      { ledEffect: { type: 'strobe', speed: 0.7, intensity: 0.6 }, brightness: 1.0, hueOverride: 0.65 },
+      drop:      { ledEffect: { type: 'lightning', speed: 0.9, intensity: 0.7 }, brightness: 1.0 },
+      build:     { ledEffect: { type: 'pulse', speed: 0.7, intensity: 0.5 }, brightness: 0.8 },
+      pulse:     { ledEffect: { type: 'pulse', speed: 0.8, intensity: 0.5 }, brightness: 0.9 },
+      epic:      { ledEffect: { type: 'chase', speed: 1.0, intensity: 0.8 }, brightness: 1.0 },
+    },
+  },
+
+  // ── Scanner ───────────────────────────────────────────────────────────────
+  // Sweeping / moving head — gradual and sweeping motion
+  scanner: {
+    default: {
+      ledEffect: { type: 'colorwave', speed: 0.4, intensity: 0.3 },
+      saturation: 1,
+      brightness: 0.65,
+    },
+    vibeOverrides: {
+      groove:    { ledEffect: { type: 'colorwave', speed: 0.5, intensity: 0.4 }, brightness: 0.7, hueOverride: 0.08 },
+      build:     { ledEffect: { type: 'chase', speed: 0.7, intensity: 0.5 }, brightness: 0.85 },
+      epic:      { ledEffect: { type: 'chase', speed: 0.9, intensity: 0.7 }, brightness: 1.0 },
+      drop:      { ledEffect: { type: 'mirror', speed: 0.8, intensity: 0.8 }, brightness: 1.0 },
+      breakdown: { ledEffect: { type: 'breathe', speed: 0.3, intensity: 0.2 }, brightness: 0.25 },
+      float:     { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.15 }, brightness: 0.2 },
+    },
+  },
+
+  // ── Background ────────────────────────────────────────────────────────────
+  // Wash / ambient LED fill — slow, mood-defining
+  background: {
+    default: {
+      ledEffect: { type: 'colorwave', speed: 0.3, intensity: 0.2 },
+      saturation: 0.8,
+      brightness: 0.5,
+    },
+    vibeOverrides: {
+      deep:      { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.3 }, brightness: 0.3, hueOverride: 0.65 },
+      chill:     { ledEffect: { type: 'breathe', speed: 0.3, intensity: 0.3 }, brightness: 0.35, hueOverride: 0.55 },
+      float:     { ledEffect: { type: 'breathe', speed: 0.15, intensity: 0.2 }, brightness: 0.2, hueOverride: 0.72 },
+      groove:    { ledEffect: { type: 'colorwave', speed: 0.4, intensity: 0.3 }, brightness: 0.6, hueOverride: 0.08 },
+      funk:      { ledEffect: { type: 'colorwave', speed: 0.5, intensity: 0.35 }, brightness: 0.7, hueOverride: 0.06 },
+      soul:      { ledEffect: { type: 'breathe', speed: 0.4, intensity: 0.4 }, brightness: 0.55, hueOverride: 0.02 },
+      drive:     { ledEffect: { type: 'colorwave', speed: 0.5, intensity: 0.3 }, brightness: 0.65, hueOverride: 0.60 },
+      pulse:     { ledEffect: { type: 'pulse', speed: 0.6, intensity: 0.4 }, brightness: 0.7 },
+      rave:      { ledEffect: { type: 'gradient', speed: 0.6, intensity: 0.4 }, brightness: 0.6, hueOverride: 0.65 },
+      build:     { ledEffect: { type: 'colorwave', speed: 0.6, intensity: 0.4 }, brightness: 0.7 },
+      drop:      { ledEffect: { type: 'pulse', speed: 1.0, intensity: 0.5 }, brightness: 1.0 },
+      breakdown: { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.15 }, brightness: 0.2, hueOverride: 0.65 },
+      tropical:  { ledEffect: { type: 'gradient', speed: 0.5, intensity: 0.5 }, brightness: 0.65, hueOverride: 0.38 },
+      dark:      { ledEffect: { type: 'breathe', speed: 0.3, intensity: 0.25 }, brightness: 0.45, hueOverride: 0.80 },
+      bright:    { ledEffect: { type: 'colorwave', speed: 0.5, intensity: 0.35 }, brightness: 0.65, hueOverride: 0.85 },
+      smooth:    { ledEffect: { type: 'breathe', speed: 0.4, intensity: 0.35 }, brightness: 0.5, hueOverride: 0.05 },
+      epic:      { ledEffect: { type: 'gradient', speed: 0.7, intensity: 0.5 }, brightness: 0.85 },
+      intimate:  { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.15 }, brightness: 0.15, hueOverride: 0.07 },
+    },
+  },
+
+  // ── Ambient ───────────────────────────────────────────────────────────────
+  // Very smooth, color only — reflects mood, ignores beat
+  ambient: {
+    default: {
+      ledEffect: { type: 'breathe', speed: 0.3, intensity: 0.4 },
+      saturation: 0.7,
+      brightness: 0.4,
+    },
+    vibeOverrides: {
+      float:     { ledEffect: { type: 'breathe', speed: 0.15, intensity: 0.3 }, brightness: 0.2, hueOverride: 0.72 },
+      chill:     { brightness: 0.3, hueOverride: 0.55 },
+      soul:      { brightness: 0.5, hueOverride: 0.02 },
+      smooth:    { brightness: 0.45, hueOverride: 0.05 },
+      intimate:  { ledEffect: { type: 'breathe', speed: 0.15, intensity: 0.2 }, brightness: 0.15, hueOverride: 0.07 },
+      funk:      { brightness: 0.65, hueOverride: 0.06 },
+      groove:    { brightness: 0.6, hueOverride: 0.08 },
+      tropical:  { brightness: 0.6, hueOverride: 0.38 },
+    },
+  },
+
+  // ── Effect ────────────────────────────────────────────────────────────────
+  // Flexible — vibe-specific, used for special effects fixtures
+  effect: {
+    default: {
+      ledEffect: { type: 'pulse', speed: 0.5, intensity: 0.5 },
+      saturation: 1,
+      brightness: 0.65,
+    },
+    vibeOverrides: {
+      build:     { ledEffect: { type: 'chase', speed: 0.7, intensity: 0.6 }, brightness: 0.8 },
+      drop:      { ledEffect: { type: 'lightning', speed: 0.9, intensity: 0.8 }, brightness: 1.0 },
+      rave:      { ledEffect: { type: 'strobe', speed: 0.7, intensity: 0.6 }, brightness: 1.0, hueOverride: 0.65 },
+      snappy:    { ledEffect: { type: 'sparkle', speed: 0.9, intensity: 0.7 }, brightness: 0.9, hueOverride: 0.33 },
+      epic:      { ledEffect: { type: 'mirror', speed: 0.8, intensity: 0.7 }, brightness: 1.0 },
+      breakdown: { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.2 }, brightness: 0.2 },
+      chill:     { ledEffect: { type: 'breathe', speed: 0.3, intensity: 0.3 }, brightness: 0.35 },
+    },
+  },
+
+  // ── Beam ──────────────────────────────────────────────────────────────────
+  // Moving head beam — sweeps based on mids + energy
+  beam: {
+    default: {
+      ledEffect: { type: 'colorwave', speed: 0.4, intensity: 0.3 },
+      saturation: 1,
+      brightness: 0.6,
+    },
+    vibeOverrides: {
+      drop:      { ledEffect: { type: 'strobe', speed: 0.5, intensity: 0.5 }, brightness: 1.0 },
+      build:     { ledEffect: { type: 'chase', speed: 0.7, intensity: 0.5 }, brightness: 0.85 },
+      epic:      { ledEffect: { type: 'mirror', speed: 0.8, intensity: 0.7 }, brightness: 1.0 },
+      breakdown: { ledEffect: { type: 'breathe', speed: 0.2, intensity: 0.2 }, brightness: 0.25 },
+      float:     { ledEffect: { type: 'breathe', speed: 0.15, intensity: 0.15 }, brightness: 0.2 },
+    },
+  },
+
+}


### PR DESCRIPTION
Introduce end-to-end audio-reactive lighting and auto-control. Adds a browser-side audio analyzer hook (useAudioAnalyzer) with real-time AudioFeatures sent to main via a new IPC channel, new Audio and AutoControl UI pages, and menu entries. The engine consumes audio features to (1) generate an automatic "Auto" scene when vibe changes, and (2) apply audio modulators to split output params; LED effects are also applied before WLED output. New shared modules (audioFeatures, ledPatterns, vibeBehavior, groupRoles) and autoControl state/slice support the behavior mapping. Also updated IPC, preload, engine, and renderer wiring to propagate audio data and control the auto-generated scene. Added architecture docs describing the system.
